### PR TITLE
Implement welzl's algorithm for finding a minimum bounding sphere

### DIFF
--- a/src/LeagueToolkit/IO/NVR/NVRMesh.cs
+++ b/src/LeagueToolkit/IO/NVR/NVRMesh.cs
@@ -45,24 +45,9 @@ namespace LeagueToolkit.IO.NVR
             this.IndexedPrimitives[0] = new NVRDrawIndexedPrimitive(this, vertices, indices, true);
             this.IndexedPrimitives[1] = new NVRDrawIndexedPrimitive(this, vertices, indices, false);
 
-            float[] min = new float[3] { vertices[0].Position.X, vertices[0].Position.Y, vertices[0].Position.Z };
-            float[] max = new float[3] { vertices[0].Position.X, vertices[0].Position.Y, vertices[0].Position.Z };
-            for (int i = 1; i < vertices.Count; i++)
-            {
-                Vector3 position = vertices[i].Position;
-                if (position.X < min[0]) { min[0] = position.X; }
-                if (position.Y < min[1]) { min[1] = position.Y; }
-                if (position.Z < min[2]) { min[2] = position.Z; }
-                if (position.X > max[0]) { max[0] = position.X; }
-                if (position.Y > max[1]) { max[1] = position.Y; }
-                if (position.Z > max[2]) { max[2] = position.Z; }
-            }
-            this.BoundingBox = new Box(new Vector3(min[0], min[1], min[2]), new Vector3(max[0], max[1], max[2]));
-
-            float radius = max[0] - min[0];
-            if (max[1] - min[1] > radius) { radius = max[1] - min[1]; }
-            if (max[2] - min[2] > radius) { radius = max[2] - min[2]; }
-            this.BoundingSphere = new R3DSphere(new Vector3((min[0] + max[0]) / 2, (min[1] + max[1]) / 2, (min[2] + max[2]) / 2), radius / 2);
+            Vector3[] allVertexPositions = vertices.Select(vertex => vertex.Position).ToArray();
+            this.BoundingBox = Box.FromVertices(allVertexPositions);
+            this.BoundingSphere = R3DSphere.CalculateBoundingSphere(allVertexPositions);
         }
 
         public void Write(BinaryWriter bw)

--- a/src/LeagueToolkit/IO/NVR/NVRNode.cs
+++ b/src/LeagueToolkit/IO/NVR/NVRNode.cs
@@ -60,51 +60,13 @@ namespace LeagueToolkit.IO.NVR
             this.CentralPointsBoundingBox = this.CalculateCentralPointsBoundingBox();
         }
 
-        private Box CalculateBoundingBox()
-        {
-            if (Meshes.Count > 0)
-            {
-                Vector3 min = new Vector3(Meshes[0].BoundingBox.Min.X, Meshes[0].BoundingBox.Min.Y, Meshes[0].BoundingBox.Min.Z);
-                Vector3 max = new Vector3(Meshes[0].BoundingBox.Max.X, Meshes[0].BoundingBox.Max.Y, Meshes[0].BoundingBox.Max.Z);
-                for (int i = 1; i < Meshes.Count; i++)
-                {
-                    Box box = Meshes[i].BoundingBox;
-                    if (box.Min.X < min.X) { min.X = box.Min.X; }
-                    if (box.Min.Y < min.Y) { min.Y = box.Min.Y; }
-                    if (box.Min.Z < min.Z) { min.Z = box.Min.Z; }
-                    if (box.Max.X > max.X) { max.X = box.Max.X; }
-                    if (box.Max.Y > max.Y) { max.Y = box.Max.Y; }
-                    if (box.Max.Z > max.Z) { max.Z = box.Max.Z; }
-                }
-                return new Box(min, max);
-            }
-            else
-            {
-                // No meshes inside, set bounding box to 
-                return new Box(new Vector3(NullCoordinate, NullCoordinate, NullCoordinate), new Vector3(NullCoordinate, NullCoordinate, NullCoordinate));
-            }
-        }
+        private Box CalculateBoundingBox() => Meshes.Count > 0
+            ? Box.FromVertices(Meshes.SelectMany(mesh => new[] { mesh.BoundingBox.Min, mesh.BoundingBox.Max }))
+            : new Box(new Vector3(NullCoordinate, NullCoordinate, NullCoordinate), new Vector3(NullCoordinate, NullCoordinate, NullCoordinate));
 
-        private Box CalculateCentralPointsBoundingBox()
-        {
-            if (Meshes.Count > 0)
-            {
-                Vector3 min = new Vector3(Meshes[0].BoundingSphere.Position.X, Meshes[0].BoundingSphere.Position.Y, Meshes[0].BoundingSphere.Position.Z);
-                Vector3 max = new Vector3(Meshes[0].BoundingSphere.Position.X, Meshes[0].BoundingSphere.Position.Y, Meshes[0].BoundingSphere.Position.Z);
-                for (int i = 1; i < Meshes.Count; i++)
-                {
-                    Vector3 spherePosition = Meshes[i].BoundingSphere.Position;
-                    if (spherePosition.X < min.X) { min.X = spherePosition.X; }
-                    if (spherePosition.Y < min.Y) { min.Y = spherePosition.Y; }
-                    if (spherePosition.Z < min.Z) { min.Z = spherePosition.Z; }
-                    if (spherePosition.X > max.X) { max.X = spherePosition.X; }
-                    if (spherePosition.Y > max.Y) { max.Y = spherePosition.Y; }
-                    if (spherePosition.Z > max.Z) { max.Z = spherePosition.Z; }
-                }
-                return new Box(min, max);
-            }
-            return new Box(new Vector3(NullCoordinate, NullCoordinate, NullCoordinate), new Vector3(NullCoordinate, NullCoordinate, NullCoordinate));
-        }
+        private Box CalculateCentralPointsBoundingBox() => Meshes.Count > 0
+            ? Box.FromVertices(Meshes.Select(mesh => mesh.BoundingSphere.Position))
+            : new Box(new Vector3(NullCoordinate, NullCoordinate, NullCoordinate), new Vector3(NullCoordinate, NullCoordinate, NullCoordinate));
 
         public void Split()
         {

--- a/src/LeagueToolkit/IO/SimpleSkinFile/SimpleSkin.cs
+++ b/src/LeagueToolkit/IO/SimpleSkinFile/SimpleSkin.cs
@@ -155,7 +155,8 @@ namespace LeagueToolkit.IO.SimpleSkinFile
 
             Box box = GetBoundingBox();
             bw.WriteBox(box);
-            box.GetBoundingSphere().Write(bw);
+            Vector3[] allVertexPositions = this.Submeshes.SelectMany(submesh => submesh.Vertices).Select(vertex => vertex.Position).Distinct().ToArray();
+            R3DSphere.CalculateBoundingSphere(allVertexPositions).Write(bw);
 
             ushort indexOffset = 0;
             foreach (SimpleSkinSubmesh submesh in this.Submeshes)

--- a/src/LeagueToolkit/IO/SimpleSkinFile/SimpleSkin.cs
+++ b/src/LeagueToolkit/IO/SimpleSkinFile/SimpleSkin.cs
@@ -153,9 +153,8 @@ namespace LeagueToolkit.IO.SimpleSkinFile
             bw.Write(SimpleSkinVertex.GetVertexTypeSize(vertexType));
             bw.Write((uint)vertexType);
 
-            Box box = GetBoundingBox();
-            bw.WriteBox(box);
             Vector3[] allVertexPositions = this.Submeshes.SelectMany(submesh => submesh.Vertices).Select(vertex => vertex.Position).Distinct().ToArray();
+            bw.WriteBox(Box.FromVertices(allVertexPositions));
             R3DSphere.CalculateBoundingSphere(allVertexPositions).Write(bw);
 
             ushort indexOffset = 0;
@@ -180,26 +179,6 @@ namespace LeagueToolkit.IO.SimpleSkinFile
             bw.Write(new byte[12]); //End tab
         }
 
-        // TODO: Use Box.FromVertices
-        public Box GetBoundingBox()
-        {
-            Vector3 min = new Vector3(float.MaxValue, float.MaxValue, float.MaxValue);
-            Vector3 max = new Vector3(float.MinValue, float.MinValue, float.MinValue);
-
-            foreach (SimpleSkinSubmesh submesh in this.Submeshes)
-            {
-                foreach (SimpleSkinVertex vertex in submesh.Vertices)
-                {
-                    if (min.X > vertex.Position.X) min.X = vertex.Position.X;
-                    if (min.Y > vertex.Position.Y) min.Y = vertex.Position.Y;
-                    if (min.Z > vertex.Position.Z) min.Z = vertex.Position.Z;
-                    if (max.X < vertex.Position.X) max.X = vertex.Position.X;
-                    if (max.Y < vertex.Position.Y) max.Y = vertex.Position.Y;
-                    if (max.Z < vertex.Position.Z) max.Z = vertex.Position.Z;
-                }
-            }
-
-            return new Box(min, max);
-        }
+        public Box GetBoundingBox() => Box.FromVertices(this.Submeshes.SelectMany(submesh => submesh.Vertices).Select(vertex => vertex.Position));
     }
 }

--- a/src/LeagueToolkit/IO/StaticObjectFile/StaticObject.cs
+++ b/src/LeagueToolkit/IO/StaticObjectFile/StaticObject.cs
@@ -405,26 +405,7 @@ namespace LeagueToolkit.IO.StaticObjectFile
             return indices;
         }
 
-        public Box GetBoundingBox()
-        {
-            Vector3 min = new Vector3(float.MaxValue, float.MaxValue, float.MaxValue);
-            Vector3 max = new Vector3(float.MinValue, float.MinValue, float.MinValue);
-
-            foreach (StaticObjectSubmesh submesh in this.Submeshes)
-            {
-                foreach (StaticObjectVertex vertex in submesh.Vertices)
-                {
-                    if (min.X > vertex.Position.X) min.X = vertex.Position.X;
-                    if (min.Y > vertex.Position.Y) min.Y = vertex.Position.Y;
-                    if (min.Z > vertex.Position.Z) min.Z = vertex.Position.Z;
-                    if (max.X < vertex.Position.X) max.X = vertex.Position.X;
-                    if (max.Y < vertex.Position.Y) max.Y = vertex.Position.Y;
-                    if (max.Z < vertex.Position.Z) max.Z = vertex.Position.Z;
-                }
-            }
-
-            return new Box(min, max);
-        }
+        public Box GetBoundingBox() => Box.FromVertices(this.Submeshes.SelectMany(submesh => submesh.Vertices).Select(vertex => vertex.Position));
         public Vector3 GetCentralPoint() => GetBoundingBox().GetCentralPoint();
     }
 

--- a/src/LeagueToolkit/IO/WorldGeometry/WorldGeometryModel.cs
+++ b/src/LeagueToolkit/IO/WorldGeometry/WorldGeometryModel.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Numerics;
 using System.Text;
 using LeagueToolkit.Helpers.Extensions;
+using System.Linq;
 
 namespace LeagueToolkit.IO.WorldGeometry
 {
@@ -57,7 +58,7 @@ namespace LeagueToolkit.IO.WorldGeometry
             this.Vertices = vertices;
             this.Indices = indices;
             this.BoundingBox = CalculateBoundingBox();
-            this.Sphere = CalculateSphere();
+            this.Sphere = CalculateBoundingSphere();
         }
 
         /// <summary>
@@ -133,62 +134,18 @@ namespace LeagueToolkit.IO.WorldGeometry
         public Tuple<R3DSphere, Box> CalculateBoundingGeometry()
         {
             Box box = CalculateBoundingBox();
-            R3DSphere sphere = CalculateSphere(box);
+            R3DSphere sphere = CalculateBoundingSphere();
             return new Tuple<R3DSphere, Box>(sphere, box);
         }
 
         /// <summary>
         /// Calculates the Axis Aligned Bounding Box of this <see cref="WorldGeometryModel"/>
         /// </summary>
-        public Box CalculateBoundingBox()
-        {
-            if(this.Vertices == null || this.Vertices.Count == 0)
-            {
-                return new Box(new Vector3(0, 0, 0), new Vector3(0, 0, 0));
-            }
-            else
-            {
-                Vector3 min = this.Vertices[0].Position;
-                Vector3 max = this.Vertices[0].Position;
-
-                foreach (WorldGeometryVertex vertex in this.Vertices)
-                {
-                    if (min.X > vertex.Position.X) min.X = vertex.Position.X;
-                    if (min.Y > vertex.Position.Y) min.Y = vertex.Position.Y;
-                    if (min.Z > vertex.Position.Z) min.Z = vertex.Position.Z;
-                    if (max.X < vertex.Position.X) max.X = vertex.Position.X;
-                    if (max.Y < vertex.Position.Y) max.Y = vertex.Position.Y;
-                    if (max.Z < vertex.Position.Z) max.Z = vertex.Position.Z;
-                }
-
-                return new Box(min, max);
-            }
-        }
+        public Box CalculateBoundingBox() => Box.FromVertices(this.Vertices.Select(vertex => vertex.Position));
 
         /// <summary>
         /// Calculates the Bounding Sphere of this <see cref="WorldGeometryModel"/>
         /// </summary>
-        public R3DSphere CalculateSphere()
-        {
-            Box box = CalculateBoundingBox();
-            Vector3 centralPoint = new Vector3(0.5f * (this.BoundingBox.Max.X + this.BoundingBox.Min.X),
-                0.5f * (this.BoundingBox.Max.Y + this.BoundingBox.Min.Y),
-                0.5f * (this.BoundingBox.Max.Z + this.BoundingBox.Min.Z));
-
-            return new R3DSphere(centralPoint, Vector3.Distance(centralPoint, box.Max));
-        }
-
-        /// <summary>
-        /// Calculates the Bounding Sphere of this <see cref="WorldGeometryModel"/> from the specified <see cref="Box"/>
-        /// </summary>
-        /// <param name="box"><see cref="Box"/> to use for calculation</param>
-        public R3DSphere CalculateSphere(Box box)
-        {
-            Vector3 centralPoint = new Vector3(0.5f * (this.BoundingBox.Max.X + this.BoundingBox.Min.X),
-                0.5f * (this.BoundingBox.Max.Y + this.BoundingBox.Min.Y),
-                0.5f * (this.BoundingBox.Max.Z + this.BoundingBox.Min.Z));
-
-            return new R3DSphere(centralPoint, Vector3.Distance(centralPoint, box.Max));
-        }
+        public R3DSphere CalculateBoundingSphere() => R3DSphere.CalculateBoundingSphere(this.Vertices.Select(vertex => vertex.Position));
     }
 }


### PR DESCRIPTION
This pull request adds an implementation of [Welzl's algorithm](https://en.wikipedia.org/wiki/Smallest-circle_problem#Welzl's_algorithm) and updates logic that previously relied on a bounding box to now calculate the bounding sphere from all points using the `CalculateBoundingSphere` function instead.
I've also added a similarly-styled `CalculateBoundingBox` function to merge all the re-implementations across the codebase into one shared place.

I have tested the `CalculateBoundingSphere` function with some champion models in maya and welzl's algorithm produces a more optimized (and thereby smaller) bounding sphere than what the "boundingbox->boundingsphere of the boundingbox" approach returns. The resulting bounding sphere also more closely resembles the original boundingsphere that is written to the original game files (in general, the original bounding sphere is slightly larger than the one calculated with welzl's algorithm, but the previous approach generated a sphere much too large).

Note also that welzl's algorithm has a worst-case complexity of $O(n^3)$, but in reality performs in $O(n)$ due to the inputs points being randomly ordered. I'm not entirely sure why randomizing the input order works, but it does (here's the original algorithm paper: https://link.springer.com/content/pdf/10.1007/BFb0038202.pdf).