### PR TITLE
Add animation writing (v3-5)

### DIFF
--- a/src/LeagueToolkit.IO.Extensions/SimpleSkinFile/SimpleSkinGltfExtensions.cs
+++ b/src/LeagueToolkit.IO.Extensions/SimpleSkinFile/SimpleSkinGltfExtensions.cs
@@ -186,28 +186,31 @@ namespace LeagueToolkit.IO.SimpleSkinFile
 
                     if (joint is not null)
                     {
-                        if (track.Translations.Count == 0) track.Translations.Add(0.0f, new Vector3(0, 0, 0));
-                        if (track.Translations.Count == 1) track.Translations.Add(1.0f, new Vector3(0, 0, 0));
+                        if (track.Translations.Count == 0) track.Translations.Add(new Vector3(0, 0, 0));
+                        if (track.Translations.Count == 1) track.Translations.Add(new Vector3(0, 0, 0));
                         CurveBuilder<Vector3> translationBuilder = joint.UseTranslation().UseTrackBuilder(animationName);
-                        foreach (var translation in track.Translations)
+                        for (int frame = 0; frame < track.Translations.Count; frame++)
                         {
-                            translationBuilder.SetPoint(translation.Key, translation.Value);
+                            Vector3 translation = track.Translations[frame];
+                            translationBuilder.SetPoint(frame * leagueAnimation.FrameDuration, translation);
                         }
 
-                        if (track.Rotations.Count == 0) track.Rotations.Add(0.0f, Quaternion.Identity);
-                        if (track.Rotations.Count == 1) track.Rotations.Add(1.0f, Quaternion.Identity);
+                        if (track.Rotations.Count == 0) track.Rotations.Add(Quaternion.Identity);
+                        if (track.Rotations.Count == 1) track.Rotations.Add(Quaternion.Identity);
                         CurveBuilder<Quaternion> rotationBuilder = joint.UseRotation().UseTrackBuilder(animationName);
-                        foreach (var rotation in track.Rotations)
+                        for (int frame = 0; frame < track.Rotations.Count; frame++)
                         {
-                            rotationBuilder.SetPoint(rotation.Key, rotation.Value);
+                            Quaternion rotation = track.Rotations[frame];
+                            rotationBuilder.SetPoint(frame * leagueAnimation.FrameDuration, rotation);
                         }
 
-                        if (track.Scales.Count == 0) track.Scales.Add(0.0f, new Vector3(1, 1, 1));
-                        if (track.Scales.Count == 1) track.Scales.Add(1.0f, new Vector3(1, 1, 1));
+                        if (track.Scales.Count == 0) track.Scales.Add(new Vector3(1, 1, 1));
+                        if (track.Scales.Count == 1) track.Scales.Add(new Vector3(1, 1, 1));
                         CurveBuilder<Vector3> scaleBuilder = joint.UseScale().UseTrackBuilder(animationName);
-                        foreach (var scale in track.Scales.ToList())
+                        for (int frame = 0; frame < track.Scales.Count; frame++)
                         {
-                            scaleBuilder.SetPoint(scale.Key, scale.Value);
+                            Vector3 scale = track.Scales[frame];
+                            scaleBuilder.SetPoint(frame * leagueAnimation.FrameDuration, scale);
                         }
                     }
                 }

--- a/src/LeagueToolkit.IO.Extensions/SimpleSkinFile/SimpleSkinGltfExtensions.cs
+++ b/src/LeagueToolkit.IO.Extensions/SimpleSkinFile/SimpleSkinGltfExtensions.cs
@@ -214,6 +214,38 @@ namespace LeagueToolkit.IO.SimpleSkinFile
                         }
                     }
                 }
+
+                foreach (QuantizedAnimationTrack quantizedTrack in leagueAnimation.QuantizedTracks)
+                {
+                    NodeBuilder joint = joints.FirstOrDefault(x => Cryptography.ElfHash(x.Name) == quantizedTrack.JointHash);
+
+                    if (joint is not null)
+                    {
+                        if (quantizedTrack.Translations.Count == 0) quantizedTrack.Translations.Add(0.0f, new Vector3(0, 0, 0));
+                        if (quantizedTrack.Translations.Count == 1) quantizedTrack.Translations.Add(1.0f, new Vector3(0, 0, 0));
+                        CurveBuilder<Vector3> translationBuilder = joint.UseTranslation().UseTrackBuilder(animationName);
+                        foreach (var translation in quantizedTrack.Translations)
+                        {
+                            translationBuilder.SetPoint(translation.Key, translation.Value);
+                        }
+
+                        if (quantizedTrack.Rotations.Count == 0) quantizedTrack.Rotations.Add(0.0f, Quaternion.Identity);
+                        if (quantizedTrack.Rotations.Count == 1) quantizedTrack.Rotations.Add(1.0f, Quaternion.Identity);
+                        CurveBuilder<Quaternion> rotationBuilder = joint.UseRotation().UseTrackBuilder(animationName);
+                        foreach (var rotation in quantizedTrack.Rotations)
+                        {
+                            rotationBuilder.SetPoint(rotation.Key, rotation.Value);
+                        }
+
+                        if (quantizedTrack.Scales.Count == 0) quantizedTrack.Scales.Add(0.0f, new Vector3(1, 1, 1));
+                        if (quantizedTrack.Scales.Count == 1) quantizedTrack.Scales.Add(1.0f, new Vector3(1, 1, 1));
+                        CurveBuilder<Vector3> scaleBuilder = joint.UseScale().UseTrackBuilder(animationName);
+                        foreach (var scale in quantizedTrack.Scales)
+                        {
+                            scaleBuilder.SetPoint(scale.Key, scale.Value);
+                        }
+                    }
+                }
             }
         }
 

--- a/src/LeagueToolkit/Helpers/Extensions/QuaternionExtensions.cs
+++ b/src/LeagueToolkit/Helpers/Extensions/QuaternionExtensions.cs
@@ -1,0 +1,24 @@
+using System.Collections.Generic;
+using System.Numerics;
+
+namespace LeagueToolkit.Helpers.Extensions
+{
+    internal static class QuaternionExtensions
+    {
+        public class QuaternionComparer : IComparer<Quaternion>
+        {
+            public static readonly QuaternionComparer Comparer = new();
+            private QuaternionComparer() { }
+
+            public int Compare(Quaternion @this, Quaternion other)
+            {
+                int xComparison = @this.X.CompareTo(other.X);
+                if (xComparison != 0) return xComparison;
+                int yComparison = @this.Y.CompareTo(other.Y);
+                if (yComparison != 0) return yComparison;
+                int zComparison = @this.Z.CompareTo(other.Z);
+                return zComparison != 0 ? zComparison : @this.W.CompareTo(other.W);
+            }
+        }
+    }
+}

--- a/src/LeagueToolkit/Helpers/Extensions/Vector3Extensions.cs
+++ b/src/LeagueToolkit/Helpers/Extensions/Vector3Extensions.cs
@@ -1,0 +1,22 @@
+using System.Collections.Generic;
+using System.Numerics;
+
+namespace LeagueToolkit.Helpers.Extensions
+{
+    internal static class Vector3Extensions
+    {
+        public class Vector3Comparer : IComparer<Vector3>
+        {
+            public static readonly Vector3Comparer Comparer = new();
+            private Vector3Comparer() { }
+
+            public int Compare(Vector3 @this, Vector3 other)
+            {
+                int xComparison = @this.X.CompareTo(other.X);
+                if (xComparison != 0) return xComparison;
+                int yComparison = @this.Y.CompareTo(other.Y);
+                return yComparison != 0 ? yComparison : @this.Z.CompareTo(other.Z);
+            }
+        }
+    }
+}

--- a/src/LeagueToolkit/Helpers/Structures/QuantizedQuaternion.cs
+++ b/src/LeagueToolkit/Helpers/Structures/QuantizedQuaternion.cs
@@ -6,6 +6,7 @@ namespace LeagueToolkit.Helpers.Structures
 {
     public readonly struct QuantizedQuaternion : IEquatable<QuantizedQuaternion>, IComparable<QuantizedQuaternion>
     {
+        private static readonly double Sqrt2 = Math.Sqrt(2);
         private readonly ushort[] _data;
 
         public QuantizedQuaternion(byte[] data)
@@ -26,10 +27,9 @@ namespace LeagueToolkit.Helpers.Structures
             ushort v_b = (ushort)((bits >> 15) & 0x7FFFu);
             ushort v_c = (ushort)(bits & 0x7FFFu);
 
-            const double sqrt2 = 1.41421356237;
-            float a = (float)((v_a / 32767.0) * sqrt2 - 1 / sqrt2);
-            float b = (float)((v_b / 32767.0) * sqrt2 - 1 / sqrt2);
-            float c = (float)((v_c / 32767.0) * sqrt2 - 1 / sqrt2);
+            float a = (float)((v_a / 32767.0) * Sqrt2 - 1 / Sqrt2);
+            float b = (float)((v_b / 32767.0) * Sqrt2 - 1 / Sqrt2);
+            float c = (float)((v_c / 32767.0) * Sqrt2 - 1 / Sqrt2);
             float sub = Math.Max(0, 1 - (a * a + b * b + c * c));
             float d = (float)Math.Sqrt(sub);
 
@@ -44,28 +44,27 @@ namespace LeagueToolkit.Helpers.Structures
 
         public static QuantizedQuaternion Compress(Quaternion quaternion)
         {
-            double sqrt2 = Math.Sqrt(2);
             float[] quaternionFloats = { quaternion.X, quaternion.Y, quaternion.Z, quaternion.W };
-            if (quaternionFloats.Any(f => -f > 1 / sqrt2))
-                quaternionFloats = quaternionFloats.Select(f => -f).ToArray(); // no float is allowed with a value of < -1 / sqrt(2)
+            if (quaternionFloats.Any(f => -f > 1 / Sqrt2))
+                quaternionFloats = Array.ConvertAll(quaternionFloats, f => -f); // no float is allowed with a value of < -1 / sqrt(2)
             int maxIndex = Array.IndexOf(quaternionFloats, quaternionFloats.Max());
             ulong bits = (ulong)((long)maxIndex << 45);
 
             for (int i = 0, compressedIndex = 0; i < 4; i++)
             {
                 if (i == maxIndex) continue;
-                ushort compressedValue = (ushort)Math.Round(32767 / 2.0 * (sqrt2 * quaternionFloats[i] + 1));
+                ushort compressedValue = (ushort)Math.Round(32767 / 2.0 * (Sqrt2 * quaternionFloats[i] + 1));
                 bits |= (ulong)(compressedValue & 0x7FFF) << (15 * (2 - compressedIndex));
 
                 compressedIndex++;
             }
 
-            return new QuantizedQuaternion(BitConverter.GetBytes(bits).Take(6).ToArray());
+            return new QuantizedQuaternion(BitConverter.GetBytes(bits));
         }
 
-        public byte[] GetBytes() => BitConverter.GetBytes(this._data[0] | (ulong)this._data[1] << 16 | (ulong)this._data[2] << 32).Take(6).ToArray();
+        public byte[] GetBytes() => BitConverter.GetBytes(this._data[0] | (ulong)this._data[1] << 16 | (ulong)this._data[2] << 32)[..6];
 
-        public bool Equals(QuantizedQuaternion other) => _data.SequenceEqual(other._data);
+        public bool Equals(QuantizedQuaternion other) => this._data.SequenceEqual(other._data);
 
         public int CompareTo(QuantizedQuaternion other) =>
             this._data[0] == other._data[0]
@@ -76,6 +75,6 @@ namespace LeagueToolkit.Helpers.Structures
 
         public override bool Equals(object obj) => obj is QuantizedQuaternion other && Equals(other);
 
-        public override int GetHashCode() => _data != null ? _data[0] + _data[1] * 17 + _data[2] * 661 : 0;
+        public override int GetHashCode() => this._data != null ? this._data[0] + this._data[1] * 17 + this._data[2] * 661 : 0;
     }
 }

--- a/src/LeagueToolkit/IO/AnimationFile/Animation.Write.cs
+++ b/src/LeagueToolkit/IO/AnimationFile/Animation.Write.cs
@@ -1,0 +1,208 @@
+using LeagueToolkit.Helpers.Extensions;
+using LeagueToolkit.Helpers.Structures;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Numerics;
+using System.Text;
+
+namespace LeagueToolkit.IO.AnimationFile
+{
+    public partial class Animation
+    {
+        public void Write(string fileLocation, uint version) => Write(File.Create(fileLocation), version);
+        public void Write(Stream stream, uint version)
+        {
+            using BinaryWriter bw = new BinaryWriter(stream);
+            switch (version)
+            {
+                case 3:
+                    WriteV3(bw);
+                    break;
+                case 4:
+                    WriteV4(bw);
+                    break;
+                case 5:
+                    WriteV5(bw);
+                    break;
+                default:
+                    throw new Exception($"Unsupported version: {version}");
+            }
+        }
+
+        private void WriteV3(BinaryWriter bw)
+        {
+            const uint nameSize = 32;
+
+            bw.Write(Encoding.ASCII.GetBytes("r3d2anmd")); // v3-5 magic
+            bw.Write(3); // version 3
+
+            bw.Write(0x84211248); // format token
+            bw.Write((uint)this.Tracks.Count); // joint count
+            bw.Write(this.FramesPerTrack);
+            bw.Write((uint)this.FPS);
+
+            byte[] nameFile = new byte[nameSize];
+
+            foreach (AnimationTrack joint in this.Tracks)
+            {
+                string name = joint.JointName;
+                if (!string.IsNullOrEmpty(name))
+                {
+                    Array.Clear(nameFile, 0, nameFile.Length);
+                    Encoding.UTF8.GetBytes(name, 0, name.Length, nameFile, 0);
+                    bw.Write(nameFile);
+                    bw.Write(joint.V3Flag);
+                    for (int frame = 0; frame < this.FramesPerTrack; frame++)
+                    {
+                        bw.WriteQuaternion(joint.Rotations[frame]);
+                        bw.WriteVector3(joint.Translations[frame]);
+                    }
+                }
+            }
+        }
+
+        private void WriteV4(BinaryWriter bw)
+        {
+            bw.Write(Encoding.ASCII.GetBytes("r3d2anmd")); // v3-5 magic
+            bw.Write(4); // version 4
+
+            bw.Seek(4, SeekOrigin.Current); // File Size, will Seek to start and write it at the end
+            bw.Seek(4, SeekOrigin.Current); // Format token, unused
+            bw.Seek(4, SeekOrigin.Current); // version, unused
+            bw.Seek(4, SeekOrigin.Current); // flags, unused
+
+            bw.Write(this.Tracks.Count);
+            bw.Write(this.FramesPerTrack);
+            bw.Write(this.FrameDuration);
+
+            const int vectorsOffset = 64;
+
+            bw.Seek(4, SeekOrigin.Current); // jointHashesOffset, unused
+            bw.Seek(4, SeekOrigin.Current); // assetNameOffset, unused
+            bw.Seek(4, SeekOrigin.Current); // timeOffset, unused
+            bw.Write(vectorsOffset);
+            bw.Seek(4, SeekOrigin.Current); // rotations offset
+            bw.Seek(4, SeekOrigin.Current); // frames offset
+
+            bw.Seek(12, SeekOrigin.Current); // padding
+
+            // write all vectors
+            List<Vector3> allVectors = this.Tracks.SelectMany(joint => joint.Scales.Concat(joint.Translations)).Distinct().ToList();
+            allVectors.Sort(Vector3Extensions.Vector3Comparer.Comparer);
+            foreach (Vector3 vector in allVectors)
+            {
+                bw.WriteVector3(vector);
+            }
+
+            // write all rotation data
+            int rotationsOffset = (int)bw.BaseStream.Position;
+            List<Quaternion> allRotations = this.Tracks.SelectMany(joint => joint.Rotations).Distinct().ToList();
+            allRotations.Sort(QuaternionExtensions.QuaternionComparer.Comparer);
+            foreach (Quaternion rotation in allRotations)
+            {
+                bw.WriteQuaternion(rotation);
+            }
+
+            // write array indices
+            int framesOffset = (int)bw.BaseStream.Position;
+            foreach (AnimationTrack joint in this.Tracks)
+            {
+                for (int frame = 0; frame < this.FramesPerTrack; frame++)
+                {
+                    bw.Write(joint.JointHash);
+                    bw.Write((ushort)allVectors.BinarySearch(joint.Translations[frame], Vector3Extensions.Vector3Comparer.Comparer));
+                    bw.Write((ushort)allVectors.BinarySearch(joint.Scales[frame], Vector3Extensions.Vector3Comparer.Comparer));
+                    bw.Write((ushort)allRotations.BinarySearch(joint.Rotations[frame], QuaternionExtensions.QuaternionComparer.Comparer));
+                    bw.Write((ushort)0); // padding
+                }
+            }
+
+            // write file size
+            uint fileSize = (uint)bw.BaseStream.Length;
+            bw.BaseStream.Seek(12, SeekOrigin.Begin);
+            bw.Write(fileSize - 12);
+
+            bw.Seek(56, SeekOrigin.Begin);
+            bw.Write(rotationsOffset - 12);
+            bw.Write(framesOffset - 12);
+        }
+
+        private void WriteV5(BinaryWriter bw)
+        {
+            bw.Write(Encoding.ASCII.GetBytes("r3d2anmd")); // v3-5 magic
+            bw.Write(5); // version 5
+
+            bw.Seek(4, SeekOrigin.Current); // File Size, will Seek to start and write it at the end
+            bw.Seek(4, SeekOrigin.Current); // Format token, unused
+            bw.Seek(4, SeekOrigin.Current); // version, unused
+            bw.Seek(4, SeekOrigin.Current); // flags, unused
+
+            bw.Write(this.Tracks.Count);
+            bw.Write(this.FramesPerTrack);
+            bw.Write(this.FrameDuration);
+
+            const int vectorsOffset = 64;
+
+            bw.Seek(4, SeekOrigin.Current); // jointHashesOffset
+            bw.Seek(4, SeekOrigin.Current); // assetNameOffset, unused
+            bw.Seek(4, SeekOrigin.Current); // timeOffset, unused
+            bw.Write(vectorsOffset);
+            bw.Seek(4, SeekOrigin.Current); // rotations offset
+            bw.Seek(4, SeekOrigin.Current); // frames offset
+
+            bw.Seek(12, SeekOrigin.Current); // padding
+
+            // write all vectors
+            List<Vector3> allVectors = this.Tracks.SelectMany(joint => joint.Scales.Concat(joint.Translations))
+                .Distinct()
+                .ToList();
+            allVectors.Sort(Vector3Extensions.Vector3Comparer.Comparer);
+            foreach (Vector3 vector in allVectors)
+            {
+                bw.WriteVector3(vector);
+            }
+
+            // write all rotation data
+            int rotationsOffset = (int)bw.BaseStream.Position;
+            List<QuantizedQuaternion> allRotationsCompressed = this.Tracks
+                .SelectMany(joint => joint.Rotations.Select(QuantizedQuaternion.Compress)).Distinct().ToList();
+            allRotationsCompressed.Sort();
+            foreach (QuantizedQuaternion compressedRotation in allRotationsCompressed)
+            {
+                bw.Write(compressedRotation.GetBytes());
+            }
+
+            // write joint hashes
+            int jointHashesOffset = (int)bw.BaseStream.Position;
+            foreach (AnimationTrack joint in this.Tracks)
+            {
+                bw.Write(joint.JointHash);
+            }
+
+            // write array indices
+            int framesOffset = (int)bw.BaseStream.Position;
+            for (int frame = 0; frame < this.FramesPerTrack; frame++)
+            {
+                foreach (AnimationTrack joint in this.Tracks)
+                {
+                    bw.Write((ushort)allVectors.BinarySearch(joint.Translations[frame], Vector3Extensions.Vector3Comparer.Comparer));
+                    bw.Write((ushort)allVectors.BinarySearch(joint.Scales[frame], Vector3Extensions.Vector3Comparer.Comparer));
+                    bw.Write((ushort)allRotationsCompressed.BinarySearch(QuantizedQuaternion.Compress(joint.Rotations[frame])));
+                }
+            }
+
+            // write file size
+            uint fileSize = (uint)bw.BaseStream.Length;
+            bw.BaseStream.Seek(12, SeekOrigin.Begin);
+            bw.Write(fileSize - 12);
+
+            bw.Seek(40, SeekOrigin.Begin);
+            bw.Write(jointHashesOffset - 12);
+            bw.Seek(56, SeekOrigin.Begin);
+            bw.Write(rotationsOffset - 12);
+            bw.Write(framesOffset - 12);
+        }
+    }
+}

--- a/src/LeagueToolkit/IO/AnimationFile/Animation.Write.cs
+++ b/src/LeagueToolkit/IO/AnimationFile/Animation.Write.cs
@@ -39,7 +39,7 @@ namespace LeagueToolkit.IO.AnimationFile
             bw.Write(3); // version 3
 
             bw.Write(0x84211248); // format token
-            bw.Write((uint)this.Tracks.Count); // joint count
+            bw.Write(this.Tracks.Count); // joint count
             bw.Write(this.FramesPerTrack);
             bw.Write((uint)this.FPS);
 
@@ -47,11 +47,10 @@ namespace LeagueToolkit.IO.AnimationFile
 
             foreach (AnimationTrack joint in this.Tracks)
             {
-                string name = joint.JointName;
-                if (!string.IsNullOrEmpty(name))
+                if (!string.IsNullOrEmpty(joint.JointName))
                 {
                     Array.Clear(nameFile, 0, nameFile.Length);
-                    Encoding.UTF8.GetBytes(name, 0, name.Length, nameFile, 0);
+                    Encoding.UTF8.GetBytes(joint.JointName, nameFile);
                     bw.Write(nameFile);
                     bw.Write(joint.V3Flag);
                     for (int frame = 0; frame < this.FramesPerTrack; frame++)
@@ -155,9 +154,7 @@ namespace LeagueToolkit.IO.AnimationFile
             bw.Seek(12, SeekOrigin.Current); // padding
 
             // write all vectors
-            List<Vector3> allVectors = this.Tracks.SelectMany(joint => joint.Scales.Concat(joint.Translations))
-                .Distinct()
-                .ToList();
+            List<Vector3> allVectors = this.Tracks.SelectMany(joint => joint.Scales.Concat(joint.Translations)).Distinct().ToList();
             allVectors.Sort(Vector3Extensions.Vector3Comparer.Comparer);
             foreach (Vector3 vector in allVectors)
             {

--- a/src/LeagueToolkit/IO/AnimationFile/Animation.Write.cs
+++ b/src/LeagueToolkit/IO/AnimationFile/Animation.Write.cs
@@ -35,7 +35,7 @@ namespace LeagueToolkit.IO.AnimationFile
         {
             const uint nameSize = 32;
 
-            bw.Write(Encoding.ASCII.GetBytes("r3d2anmd")); // v3-5 magic
+            bw.Write("r3d2anmd"u8); // v3-5 magic
             bw.Write(3); // version 3
 
             bw.Write(0x84211248); // format token
@@ -64,7 +64,7 @@ namespace LeagueToolkit.IO.AnimationFile
 
         private void WriteV4(BinaryWriter bw)
         {
-            bw.Write(Encoding.ASCII.GetBytes("r3d2anmd")); // v3-5 magic
+            bw.Write("r3d2anmd"u8); // v3-5 magic
             bw.Write(4); // version 4
 
             bw.Seek(4, SeekOrigin.Current); // File Size, will Seek to start and write it at the end
@@ -130,7 +130,7 @@ namespace LeagueToolkit.IO.AnimationFile
 
         private void WriteV5(BinaryWriter bw)
         {
-            bw.Write(Encoding.ASCII.GetBytes("r3d2anmd")); // v3-5 magic
+            bw.Write("r3d2anmd"u8); // v3-5 magic
             bw.Write(5); // version 5
 
             bw.Seek(4, SeekOrigin.Current); // File Size, will Seek to start and write it at the end

--- a/src/LeagueToolkit/IO/AnimationFile/Animation.cs
+++ b/src/LeagueToolkit/IO/AnimationFile/Animation.cs
@@ -33,12 +33,12 @@ namespace LeagueToolkit.IO.AnimationFile
 
                 if (magic == "r3d2canm")
                 {
-                    QuantizedTracks = new();
+                    this.QuantizedTracks = new();
                     ReadCompressed(br);
                 }
                 else if (magic == "r3d2anmd")
                 {
-                    Tracks = new();
+                    this.Tracks = new();
                     if (version == 5)
                     {
                         ReadV5(br);
@@ -348,7 +348,7 @@ namespace LeagueToolkit.IO.AnimationFile
 
                 AnimationTrack track = new AnimationTrack(trackName) { V3Flag = flags };
 
-                for(int frame = 0; frame < FramesPerTrack; frame++)
+                for(int frame = 0; frame < this.FramesPerTrack; frame++)
                 {
                     track.Rotations.Add(br.ReadQuaternion());
                     track.Translations.Add(br.ReadVector3());

--- a/src/LeagueToolkit/IO/AnimationFile/Animation.cs
+++ b/src/LeagueToolkit/IO/AnimationFile/Animation.cs
@@ -12,12 +12,14 @@ using System.Text;
 
 namespace LeagueToolkit.IO.AnimationFile
 {
-    public class Animation
+    public partial class Animation
     {
         public float FrameDuration { get; private set; }
         public float FPS => 1 / this.FrameDuration;
+        public int FramesPerTrack { get; private set; }
 
-        public List<AnimationTrack> Tracks { get; private set; } = new();
+        public List<AnimationTrack> Tracks { get; private set; }
+        public List<QuantizedAnimationTrack> QuantizedTracks { get; private set; }
 
         private List<List<ushort>> _jumpCaches = new();
 
@@ -31,10 +33,12 @@ namespace LeagueToolkit.IO.AnimationFile
 
                 if (magic == "r3d2canm")
                 {
+                    QuantizedTracks = new();
                     ReadCompressed(br);
                 }
                 else if (magic == "r3d2anmd")
                 {
+                    Tracks = new();
                     if (version == 5)
                     {
                         ReadV5(br);
@@ -108,7 +112,7 @@ namespace LeagueToolkit.IO.AnimationFile
                 scales.Add(jointHash, new Dictionary<float, Vector3>());
                 rotations.Add(jointHash, new Dictionary<float, Quaternion>());
 
-                this.Tracks.Add(new AnimationTrack(jointHash));
+                this.QuantizedTracks.Add(new QuantizedAnimationTrack(jointHash));
             }
             
             for(int i = 0; i < frameCount; i++)
@@ -161,7 +165,7 @@ namespace LeagueToolkit.IO.AnimationFile
             for(int i = 0; i < jointCount; i++)
             {
                 uint jointHash = jointHashes[i];
-                AnimationTrack track = this.Tracks.First(x => x.JointHash == jointHash);
+                QuantizedAnimationTrack track = this.QuantizedTracks.First(x => x.JointHash == jointHash);
 
                 track.Translations = translations[jointHash];
                 track.Scales = scales[jointHash];
@@ -192,7 +196,7 @@ namespace LeagueToolkit.IO.AnimationFile
             uint flags = br.ReadUInt32();
 
             int trackCount = br.ReadInt32();
-            int frameCount = br.ReadInt32();
+            this.FramesPerTrack =  br.ReadInt32();
             this.FrameDuration = br.ReadSingle();
 
             int tracksOffset = br.ReadInt32();
@@ -224,8 +228,8 @@ namespace LeagueToolkit.IO.AnimationFile
             }
 
             br.BaseStream.Seek(framesOffset + 12, SeekOrigin.Begin);
-            List<(uint, ushort, ushort, ushort)> frames = new(frameCount * trackCount);
-            for(int i = 0; i < frameCount * trackCount; i++)
+            List<(uint, ushort, ushort, ushort)> frames = new(FramesPerTrack * trackCount);
+            for(int i = 0; i < this.FramesPerTrack * trackCount; i++)
             {
                 frames.Add((br.ReadUInt32(), br.ReadUInt16(), br.ReadUInt16(), br.ReadUInt16()));
                 br.ReadUInt16(); // padding
@@ -240,17 +244,9 @@ namespace LeagueToolkit.IO.AnimationFile
 
                 AnimationTrack track = this.Tracks.First(x => x.JointHash == jointHash);
 
-                int trackFrameTranslationIndex = track.Translations.Count;
-                int trackFrameScaleIndex = track.Scales.Count;
-                int trackFrameRotationIndex = track.Rotations.Count;
-
-                Vector3 translation = vectors[translationIndex];
-                Vector3 scale = vectors[scaleIndex];
-                Quaternion rotation = rotations[rotationIndex];
-
-                track.Translations.Add(this.FrameDuration * trackFrameTranslationIndex, translation);
-                track.Scales.Add(this.FrameDuration * trackFrameScaleIndex, scale);
-                track.Rotations.Add(this.FrameDuration * trackFrameRotationIndex, rotation);
+                track.Translations.Add(vectors[translationIndex]);
+                track.Scales.Add(vectors[scaleIndex]);
+                track.Rotations.Add(rotations[rotationIndex]);
             }
         }
 
@@ -262,7 +258,7 @@ namespace LeagueToolkit.IO.AnimationFile
             uint flags = br.ReadUInt32();
 
             int trackCount = br.ReadInt32();
-            int framesPerTrack = br.ReadInt32();
+            this.FramesPerTrack = br.ReadInt32();
             this.FrameDuration = br.ReadSingle();
 
             int jointHashesOffset = br.ReadInt32();
@@ -284,7 +280,7 @@ namespace LeagueToolkit.IO.AnimationFile
             List<uint> jointHashes = new(jointHashesCount);
             List<Vector3> vectors = new(vectorsCount);
             List<Quaternion> rotations = new(rotationsCount);
-            var frames = new List<(ushort, ushort, ushort)>(framesPerTrack * trackCount);
+            var frames = new List<(ushort, ushort, ushort)>(this.FramesPerTrack * trackCount);
 
             // Read Joint Hashes
             br.BaseStream.Seek(jointHashesOffset + 12, SeekOrigin.Begin);
@@ -311,7 +307,7 @@ namespace LeagueToolkit.IO.AnimationFile
 
             // Read Frames
             br.BaseStream.Seek(framesOffset + 12, SeekOrigin.Begin);
-            for (int i = 0; i < framesPerTrack * trackCount; i++)
+            for (int i = 0; i < this.FramesPerTrack * trackCount; i++)
             {
                 frames.Add((br.ReadUInt16(), br.ReadUInt16(), br.ReadUInt16()));
             }
@@ -325,16 +321,13 @@ namespace LeagueToolkit.IO.AnimationFile
             for(int t = 0; t < trackCount; t++)
             {
                 AnimationTrack track = this.Tracks[t];
-                float currentTime = 0;
-                for (int f = 0; f < framesPerTrack; f++)
+                for (int f = 0; f < this.FramesPerTrack; f++)
                 {
                     (int translationIndex, int scaleIndex, int rotationIndex) = frames[f * trackCount + t];
 
-                    track.Translations.Add(currentTime, vectors[translationIndex]);
-                    track.Scales.Add(currentTime, vectors[scaleIndex]);
-                    track.Rotations.Add(currentTime, rotations[rotationIndex]);
-
-                    currentTime += this.FrameDuration;
+                    track.Translations.Add(vectors[translationIndex]);
+                    track.Scales.Add(vectors[scaleIndex]);
+                    track.Rotations.Add(rotations[rotationIndex]);
                 }
             }
         }
@@ -344,7 +337,7 @@ namespace LeagueToolkit.IO.AnimationFile
             uint skeletonId = br.ReadUInt32();
             
             int trackCount = br.ReadInt32();
-            int frameCount = br.ReadInt32();
+            this.FramesPerTrack = br.ReadInt32();
             
             this.FrameDuration = 1.0f / br.ReadInt32(); // FPS
 
@@ -353,16 +346,13 @@ namespace LeagueToolkit.IO.AnimationFile
                 string trackName = br.ReadPaddedString(32);
                 uint flags = br.ReadUInt32();
 
-                AnimationTrack track = new AnimationTrack(Cryptography.ElfHash(trackName));
+                AnimationTrack track = new AnimationTrack(trackName) { V3Flag = flags };
 
-                float frameTime = 0f;
-                for(int j = 0; j < frameCount; j++)
+                for(int frame = 0; frame < FramesPerTrack; frame++)
                 {
-                    track.Rotations.Add(frameTime, br.ReadQuaternion());
-                    track.Translations.Add(frameTime, br.ReadVector3());
-                    track.Scales.Add(frameTime, new Vector3(1, 1, 1));
-
-                    frameTime += this.FrameDuration;
+                    track.Rotations.Add(br.ReadQuaternion());
+                    track.Translations.Add(br.ReadVector3());
+                    track.Scales.Add(new Vector3(1, 1, 1));
                 }
 
                 this.Tracks.Add(track);
@@ -401,7 +391,7 @@ namespace LeagueToolkit.IO.AnimationFile
         }
         private void TranslationDequantizationRound(TransformQuantizationProperties quantizationProperties)
         {
-            foreach (AnimationTrack track in this.Tracks)
+            foreach (QuantizedAnimationTrack track in this.QuantizedTracks)
             {
                 List<(float, Vector3)> interpolatedFrames = new();
                 for (int i = 0; i < track.Translations.Count; i++)

--- a/src/LeagueToolkit/IO/AnimationFile/AnimationTrack.cs
+++ b/src/LeagueToolkit/IO/AnimationFile/AnimationTrack.cs
@@ -1,21 +1,27 @@
-﻿using System;
+﻿using LeagueToolkit.Helpers.Cryptography;
 using System.Collections.Generic;
 using System.Numerics;
-using System.Text;
 
 namespace LeagueToolkit.IO.AnimationFile
 {
     public class AnimationTrack
     {
-        public uint JointHash { get; private set; }
+        public uint JointHash { get; }
+        public string JointName { get; }
+        internal uint V3Flag { get; set; }
 
-        public Dictionary<float, Vector3> Translations { get; internal set; } = new();
-        public Dictionary<float, Vector3> Scales { get; internal set; } = new();
-        public Dictionary<float, Quaternion> Rotations { get; internal set; } = new();
+        public List<Vector3> Translations { get; } = new();
+        public List<Vector3> Scales { get; } = new();
+        public List<Quaternion> Rotations { get; } = new();
 
         internal AnimationTrack(uint jointHash)
         {
             this.JointHash = jointHash;
+        }
+
+        internal AnimationTrack(string jointName) : this(Cryptography.ElfHash(jointName))
+        {
+            this.JointName = jointName;
         }
     }
 }

--- a/src/LeagueToolkit/IO/AnimationFile/QuantizedAnimationTrack.cs
+++ b/src/LeagueToolkit/IO/AnimationFile/QuantizedAnimationTrack.cs
@@ -1,0 +1,19 @@
+using System.Collections.Generic;
+using System.Numerics;
+
+namespace LeagueToolkit.IO.AnimationFile
+{
+    public class QuantizedAnimationTrack
+    {
+        public uint JointHash { get; private set; }
+
+        public Dictionary<float, Vector3> Translations { get; internal set; } = new();
+        public Dictionary<float, Vector3> Scales { get; internal set; } = new();
+        public Dictionary<float, Quaternion> Rotations { get; internal set; } = new();
+
+        internal QuantizedAnimationTrack(uint jointHash)
+        {
+            this.JointHash = jointHash;
+        }
+    }
+}


### PR DESCRIPTION
The current structure wasn't ideally suited for writing animation files back to disk so I had to restructure some of it.

Mostly the current merging of v3-5 and v1 (compressed) animation to one class is an issue, as the formats aren't directly interchangable and the dictionary of `time -> data` is not well suited for writing it back into a v3-5 animation file, so I've got rid of the dictionaries for those versions.