### PR TITLE
featuring bintree difference

### DIFF
--- a/src/LeagueToolkit.Tests/Core/Meta/BinTreeDiffTests.cs
+++ b/src/LeagueToolkit.Tests/Core/Meta/BinTreeDiffTests.cs
@@ -1,0 +1,116 @@
+using LeagueToolkit.Core.Meta;
+using LeagueToolkit.Core.Meta.Properties;
+
+namespace LeagueToolkit.Tests.Core.Meta;
+
+public class BinTreeDiffTests
+{
+    [Fact]
+    public void Should_Return_Empty_Diff_For_Equal_Trees()
+    {
+        BinTree oldTree = CreateTree(new BinTreeString(0x10, "same"));
+        BinTree newTree = CreateTree(new BinTreeString(0x10, "same"));
+
+        BinTreeDiff diff = oldTree.Diff(newTree);
+
+        Assert.True(diff.IsEmpty);
+    }
+
+    [Fact]
+    public void Should_Report_Added_And_Removed_Objects_In_Hash_Order()
+    {
+        BinTree oldTree = new(new[] { new BinTreeObject(0x20, 1, Array.Empty<BinTreeProperty>()) }, Array.Empty<string>());
+        BinTree newTree = new(new[] { new BinTreeObject(0x10, 1, Array.Empty<BinTreeProperty>()) }, Array.Empty<string>());
+
+        BinTreeDiff diff = oldTree.Diff(newTree);
+
+        Assert.Collection(
+            diff.Objects,
+            change =>
+            {
+                Assert.Equal(BinTreeDiffKind.Added, change.Kind);
+                Assert.Equal(0x10u, change.PathHash);
+            },
+            change =>
+            {
+                Assert.Equal(BinTreeDiffKind.Removed, change.Kind);
+                Assert.Equal(0x20u, change.PathHash);
+            }
+        );
+    }
+
+    [Fact]
+    public void Should_Report_Changed_Object_Class()
+    {
+        BinTree oldTree = new(new[] { new BinTreeObject(1, 0x10, Array.Empty<BinTreeProperty>()) }, Array.Empty<string>());
+        BinTree newTree = new(new[] { new BinTreeObject(1, 0x20, Array.Empty<BinTreeProperty>()) }, Array.Empty<string>());
+
+        ModifiedBinTreeObjectDiff change = Assert.IsType<ModifiedBinTreeObjectDiff>(
+            Assert.Single(oldTree.Diff(newTree).Objects)
+        );
+
+        Assert.Equal(BinTreeDiffKind.Modified, change.Kind);
+        Assert.Empty(change.Properties);
+        Assert.Equal(0x10u, change.OldObject.ClassHash);
+        Assert.Equal(0x20u, change.NewObject.ClassHash);
+    }
+
+    [Fact]
+    public void Should_Report_Added_Removed_And_Modified_Properties()
+    {
+        BinTree oldTree = CreateTree(
+            new BinTreeString(0x10, "old"),
+            new BinTreeU32(0x30, 1)
+        );
+        BinTree newTree = CreateTree(
+            new BinTreeString(0x10, "new"),
+            new BinTreeBool(0x20, true)
+        );
+
+        ModifiedBinTreeObjectDiff objectChange = Assert.IsType<ModifiedBinTreeObjectDiff>(
+            Assert.Single(oldTree.Diff(newTree).Objects)
+        );
+
+        Assert.Collection(
+            objectChange.Properties,
+            change => Assert.Equal(BinTreeDiffKind.Modified, change.Kind),
+            change => Assert.Equal(BinTreeDiffKind.Added, change.Kind),
+            change => Assert.Equal(BinTreeDiffKind.Removed, change.Kind)
+        );
+    }
+
+    [Fact]
+    public void Should_Descend_Into_Struct_Properties()
+    {
+        BinTree oldTree = CreateTree(new BinTreeStruct(0x10, 0x100, new[] { new BinTreeString(0x20, "old") }));
+        BinTree newTree = CreateTree(new BinTreeStruct(0x10, 0x100, new[] { new BinTreeString(0x20, "new") }));
+
+        ModifiedBinTreeObjectDiff objectChange = Assert.IsType<ModifiedBinTreeObjectDiff>(
+            Assert.Single(oldTree.Diff(newTree).Objects)
+        );
+        BinTreePropertyDiff change = Assert.Single(objectChange.Properties);
+
+        Assert.Equal(new uint[] { 0x10, 0x20 }, change.Path);
+        Assert.Equal(BinTreeDiffKind.Modified, change.Kind);
+    }
+
+    [Fact]
+    public void Should_Report_Container_ElementType_Changes()
+    {
+        BinTree oldTree = CreateTree(new BinTreeContainer(0x10, BinPropertyType.U8, Array.Empty<BinTreeU8>()));
+        BinTree newTree = CreateTree(new BinTreeContainer(0x10, BinPropertyType.U32, Array.Empty<BinTreeU32>()));
+
+        ModifiedBinTreeObjectDiff objectChange = Assert.IsType<ModifiedBinTreeObjectDiff>(
+            Assert.Single(oldTree.Diff(newTree).Objects)
+        );
+        ModifiedBinTreePropertyDiff propertyChange = Assert.IsType<ModifiedBinTreePropertyDiff>(
+            Assert.Single(objectChange.Properties)
+        );
+
+        Assert.Equal(BinPropertyType.U8, ((BinTreeContainer)propertyChange.OldProperty).ElementType);
+        Assert.Equal(BinPropertyType.U32, ((BinTreeContainer)propertyChange.NewProperty).ElementType);
+    }
+
+    private static BinTree CreateTree(params BinTreeProperty[] properties) =>
+        new(new[] { new BinTreeObject(1, 2, properties) }, Array.Empty<string>());
+}

--- a/src/LeagueToolkit.Tests/Core/Meta/Properties/BinTreeContainerTests.cs
+++ b/src/LeagueToolkit.Tests/Core/Meta/Properties/BinTreeContainerTests.cs
@@ -62,6 +62,15 @@ public class BinTreeContainerTests
         }
 
         [Fact]
+        public void Should_Return_False_If_ElementType_Is_Different()
+        {
+            BinTreeContainer container1 = new(0x1, BinPropertyType.U8, Array.Empty<BinTreeU8>());
+            BinTreeContainer container2 = new(0x1, BinPropertyType.U32, Array.Empty<BinTreeU32>());
+
+            Assert.False(container1.Equals(container2));
+        }
+
+        [Fact]
         public void Should_Return_True_If_Other_Has_Same_NameHash_And_Elements()
         {
             BinTreeU8 firstElement = new(0, 1);
@@ -71,6 +80,15 @@ public class BinTreeContainerTests
             BinTreeContainer container2 = new(0x1, BinPropertyType.U8, new[] { firstElement, secondElement });
 
             Assert.True(container1.Equals(container2));
+        }
+
+        [Fact]
+        public void Unordered_Should_Return_False_If_ElementType_Is_Different()
+        {
+            BinTreeUnorderedContainer container1 = new(0x1, BinPropertyType.U8, Array.Empty<BinTreeU8>());
+            BinTreeUnorderedContainer container2 = new(0x1, BinPropertyType.U32, Array.Empty<BinTreeU32>());
+
+            Assert.False(container1.Equals(container2));
         }
     }
 }

--- a/src/LeagueToolkit.Tests/Core/Meta/Properties/BinTreeOptionalTests.cs
+++ b/src/LeagueToolkit.Tests/Core/Meta/Properties/BinTreeOptionalTests.cs
@@ -1,0 +1,49 @@
+using LeagueToolkit.Core.Meta;
+using LeagueToolkit.Core.Meta.Properties;
+
+namespace LeagueToolkit.Tests.Core.Meta.Properties;
+
+public class BinTreeOptionalTests
+{
+    public class EqualsTests
+    {
+        [Fact]
+        public void Should_Return_True_When_Both_Values_Are_Null()
+        {
+            BinTreeOptional first = new(1, null);
+            BinTreeOptional second = new(1, null);
+
+            Assert.True(first.Equals(second));
+        }
+
+        [Fact]
+        public void Should_Return_False_When_Only_One_Value_Is_Null()
+        {
+            BinTreeOptional empty = new(1, null);
+            BinTreeOptional populated = new(1, new BinTreeString(0, "value"));
+
+            Assert.False(empty.Equals(populated));
+            Assert.False(populated.Equals(empty));
+        }
+
+        [Fact]
+        public void Should_Compare_Null_Optionals_Inside_Containers()
+        {
+            BinTreeOptional firstOptional = new(0, null);
+            BinTreeOptional secondOptional = new(0, null);
+            BinTreeContainer first = new(1, BinPropertyType.Optional, new[] { firstOptional });
+            BinTreeContainer second = new(1, BinPropertyType.Optional, new[] { secondOptional });
+
+            Assert.True(first.Equals(second));
+        }
+
+        [Fact]
+        public void Should_Compare_Null_Optionals_Inside_Structs()
+        {
+            BinTreeStruct first = new(1, 2, new[] { new BinTreeOptional(3, null) });
+            BinTreeStruct second = new(1, 2, new[] { new BinTreeOptional(3, null) });
+
+            Assert.True(first.Equals(second));
+        }
+    }
+}

--- a/src/LeagueToolkit/Core/Animation/AnimationAsset.cs
+++ b/src/LeagueToolkit/Core/Animation/AnimationAsset.cs
@@ -1,5 +1,6 @@
 ﻿using System.Numerics;
 using System.Text;
+using LeagueToolkit.Utils.Extensions;
 
 namespace LeagueToolkit.Core.Animation;
 

--- a/src/LeagueToolkit/Core/Animation/AnimationAsset.cs
+++ b/src/LeagueToolkit/Core/Animation/AnimationAsset.cs
@@ -44,7 +44,7 @@ public static class AnimationAsset
     {
         using BinaryReader br = new(stream, Encoding.UTF8, true);
 
-        string magic = Encoding.ASCII.GetString(br.ReadBytes(8));
+        string magic = br.ReadFixedString(8, Encoding.ASCII);
         br.BaseStream.Seek(0, SeekOrigin.Begin);
 
         return magic switch

--- a/src/LeagueToolkit/Core/Animation/CompressedAnimationAsset.cs
+++ b/src/LeagueToolkit/Core/Animation/CompressedAnimationAsset.cs
@@ -60,7 +60,7 @@ public sealed class CompressedAnimationAsset : IAnimationAsset
     {
         using BinaryReader br = new(stream, Encoding.UTF8, true);
 
-        string magic = Encoding.ASCII.GetString(br.ReadBytes(8));
+        string magic = br.ReadFixedString(8, Encoding.ASCII);
         uint version = br.ReadUInt32();
 
         if (magic is "r3d2anmd")

--- a/src/LeagueToolkit/Core/Animation/RigResource.cs
+++ b/src/LeagueToolkit/Core/Animation/RigResource.cs
@@ -167,7 +167,7 @@ public sealed class RigResource
 
     private void ReadLegacy(BinaryReader br)
     {
-        string magic = Encoding.ASCII.GetString(br.ReadBytes(8));
+        string magic = br.ReadFixedString(8, Encoding.ASCII);
         if (magic != "r3d2sklt")
             throw new InvalidFileSignatureException();
 
@@ -399,18 +399,23 @@ internal readonly struct RigResourceLegacyJoint
         string name = br.ReadPaddedString(32);
         short parentId = (short)br.ReadInt32();
         float radius = br.ReadSingle();
-        float[,] transform = new float[4, 4];
-        transform[0, 3] = 0;
-        transform[1, 3] = 0;
-        transform[2, 3] = 0;
-        transform[3, 3] = 1;
-        for (int i = 0; i < 3; i++)
-        {
-            for (int j = 0; j < 4; j++)
-            {
-                transform[j, i] = br.ReadSingle();
-            }
-        }
+
+        // Matrix is stored as 3 columns of 4 rows (column-major)
+        // Read directly into fields to avoid allocations
+        float m11 = br.ReadSingle();
+        float m21 = br.ReadSingle();
+        float m31 = br.ReadSingle();
+        float m41 = br.ReadSingle();
+
+        float m12 = br.ReadSingle();
+        float m22 = br.ReadSingle();
+        float m32 = br.ReadSingle();
+        float m42 = br.ReadSingle();
+
+        float m13 = br.ReadSingle();
+        float m23 = br.ReadSingle();
+        float m33 = br.ReadSingle();
+        float m43 = br.ReadSingle();
 
         return new()
         {
@@ -420,22 +425,10 @@ internal readonly struct RigResourceLegacyJoint
             Radius = radius,
             GlobalTransform = new Matrix4x4()
             {
-                M11 = transform[0, 0],
-                M12 = transform[0, 1],
-                M13 = transform[0, 2],
-                M14 = transform[0, 3],
-                M21 = transform[1, 0],
-                M22 = transform[1, 1],
-                M23 = transform[1, 2],
-                M24 = transform[1, 3],
-                M31 = transform[2, 0],
-                M32 = transform[2, 1],
-                M33 = transform[2, 2],
-                M34 = transform[2, 3],
-                M41 = transform[3, 0],
-                M42 = transform[3, 1],
-                M43 = transform[3, 2],
-                M44 = transform[3, 3],
+                M11 = m11, M12 = m12, M13 = m13, M14 = 0,
+                M21 = m21, M22 = m22, M23 = m23, M24 = 0,
+                M31 = m31, M32 = m32, M33 = m33, M34 = 0,
+                M41 = m41, M42 = m42, M43 = m43, M44 = 1,
             }
         };
     }

--- a/src/LeagueToolkit/Core/Animation/RigResource.cs
+++ b/src/LeagueToolkit/Core/Animation/RigResource.cs
@@ -59,8 +59,8 @@ public sealed class RigResource
         this.Flags = flags;
         this.Name = name;
         this.AssetName = assetName;
-        this._joints = joints.ToArray();
-        this._influences = influences.ToArray();
+        this._joints = joints as Joint[] ?? joints.ToArray();
+        this._influences = influences as short[] ?? influences.ToArray();
     }
 
     /// <summary>

--- a/src/LeagueToolkit/Core/Animation/UncompressedAnimationAsset.cs
+++ b/src/LeagueToolkit/Core/Animation/UncompressedAnimationAsset.cs
@@ -30,7 +30,7 @@ public sealed class UncompressedAnimationAsset : IAnimationAsset
     {
         using BinaryReader br = new(stream, Encoding.UTF8, true);
 
-        string magic = Encoding.ASCII.GetString(br.ReadBytes(8));
+        string magic = br.ReadFixedString(8, Encoding.ASCII);
         uint version = br.ReadUInt32();
 
         if (magic is "r3d2canm")

--- a/src/LeagueToolkit/Core/Environment/Builder/EnvironmentAssetMeshBuilder.cs
+++ b/src/LeagueToolkit/Core/Environment/Builder/EnvironmentAssetMeshBuilder.cs
@@ -152,7 +152,7 @@ public sealed class EnvironmentAssetMeshBuilder
         Vector2 bias
     )
     {
-        this._textureOverrides = textureOverrides.ToArray();
+        this._textureOverrides = textureOverrides as EnvironmentAssetMeshTextureOverride[] ?? textureOverrides.ToArray();
         this._bakedPaintScale = scale;
         this._bakedPaintBias = bias;
         return this;

--- a/src/LeagueToolkit/Core/Environment/EnvironmentAsset.cs
+++ b/src/LeagueToolkit/Core/Environment/EnvironmentAsset.cs
@@ -55,8 +55,8 @@ public sealed class EnvironmentAsset : IDisposable
         this._sceneGraphs = new(sceneGraphs);
         this._planarReflectors = new(planarReflectors);
 
-        this._vertexBuffers = vertexBuffers.ToArray();
-        this._indexBuffers = indexBuffers.ToArray();
+        this._vertexBuffers = vertexBuffers as VertexBuffer[] ?? vertexBuffers.ToArray();
+        this._indexBuffers = indexBuffers as IndexBuffer[] ?? indexBuffers.ToArray();
     }
 
     /// <summary>
@@ -69,7 +69,7 @@ public sealed class EnvironmentAsset : IDisposable
     {
         using BinaryReader br = new(stream, Encoding.UTF8, true);
 
-        string magic = Encoding.ASCII.GetString(br.ReadBytes(4));
+        string magic = br.ReadFixedString(4, Encoding.ASCII);
         if (magic != "OEGM")
             throw new InvalidFileSignatureException();
 

--- a/src/LeagueToolkit/Core/Environment/EnvironmentAssetChannel.cs
+++ b/src/LeagueToolkit/Core/Environment/EnvironmentAssetChannel.cs
@@ -48,7 +48,7 @@ public struct EnvironmentAssetChannel
     {
         return new()
         {
-            Texture = Encoding.UTF8.GetString(br.ReadBytes(br.ReadInt32())),
+            Texture = br.ReadSizedString(Encoding.UTF8),
             Scale = br.ReadVector2(),
             Bias = br.ReadVector2()
         };

--- a/src/LeagueToolkit/Core/Environment/EnvironmentAssetMesh.cs
+++ b/src/LeagueToolkit/Core/Environment/EnvironmentAssetMesh.cs
@@ -165,7 +165,7 @@ public sealed class EnvironmentAssetMesh
         int version
     )
     {
-        this.Name = version <= 11 ? Encoding.ASCII.GetString(br.ReadBytes(br.ReadInt32())) : CreateName(id);
+        this.Name = version <= 11 ? br.ReadSizedString(Encoding.ASCII) : CreateName(id);
 
         int vertexCount = br.ReadInt32();
         uint vertexDeclarationCount = br.ReadUInt32();

--- a/src/LeagueToolkit/Core/Environment/EnvironmentAssetMeshPrimitive.cs
+++ b/src/LeagueToolkit/Core/Environment/EnvironmentAssetMeshPrimitive.cs
@@ -1,4 +1,5 @@
 ﻿using LeagueToolkit.Hashing;
+using LeagueToolkit.Utils.Extensions;
 using System.Text;
 
 namespace LeagueToolkit.Core.Environment;
@@ -56,7 +57,7 @@ public readonly struct EnvironmentAssetMeshPrimitive
     internal EnvironmentAssetMeshPrimitive(BinaryReader br)
     {
         this.Hash = br.ReadUInt32();
-        this.Material = Encoding.ASCII.GetString(br.ReadBytes(br.ReadInt32()));
+        this.Material = br.ReadSizedString(Encoding.ASCII);
         this.StartIndex = br.ReadInt32();
         this.IndexCount = br.ReadInt32();
         this.MinVertex = br.ReadInt32();

--- a/src/LeagueToolkit/Core/Environment/SimpleEnvironment.cs
+++ b/src/LeagueToolkit/Core/Environment/SimpleEnvironment.cs
@@ -15,7 +15,7 @@ public static class SimpleEnvironment
     {
         using BinaryReader br = new(stream, Encoding.UTF8, true);
 
-        string magic = Encoding.UTF8.GetString(br.ReadBytes(4));
+        string magic = br.ReadFixedString(4, Encoding.UTF8);
         if (magic is not "NVR\0")
             throw new InvalidFileSignatureException();
 

--- a/src/LeagueToolkit/Core/Environment/SimpleEnvironmentMaterial.cs
+++ b/src/LeagueToolkit/Core/Environment/SimpleEnvironmentMaterial.cs
@@ -25,7 +25,7 @@ internal readonly struct SimpleEnvironmentMaterial
         this.Name = name;
         this.Type = type;
         this.Flags = flags;
-        this.Channels = channels.ToArray();
+        this.Channels = channels as SimpleEnvironmentChannel[] ?? channels.ToArray();
     }
 
     public static SimpleEnvironmentMaterial Read(BinaryReader br)

--- a/src/LeagueToolkit/Core/Environment/WorldGeometry.cs
+++ b/src/LeagueToolkit/Core/Environment/WorldGeometry.cs
@@ -19,7 +19,7 @@ public static class WorldGeometry
     {
         using BinaryReader br = new(stream, Encoding.UTF8, true);
 
-        string magic = Encoding.ASCII.GetString(br.ReadBytes(4));
+        string magic = br.ReadFixedString(4, Encoding.ASCII);
         if (magic is not "WGEO")
             throw new InvalidFileSignatureException();
 

--- a/src/LeagueToolkit/Core/Legacy/IO/AiMesh/AiMeshFile.cs
+++ b/src/LeagueToolkit/Core/Legacy/IO/AiMesh/AiMeshFile.cs
@@ -1,4 +1,5 @@
 ﻿using LeagueToolkit.Utils.Exceptions;
+using LeagueToolkit.Utils.Extensions;
 using System.Text;
 
 namespace LeagueToolkit.IO.AiMesh;
@@ -11,7 +12,7 @@ public class AiMeshFile
     /// <summary>
     /// A collection of <see cref="AiMeshCell"/>
     /// </summary>
-    public List<AiMeshCell> Cells { get; private set; }
+    public List<AiMeshCell> Cells { get; private set; } = new();
 
     /// <summary>
     /// Initializes a new <see cref="AiMeshFile"/> with cells
@@ -35,7 +36,7 @@ public class AiMeshFile
     {
         using (BinaryReader br = new BinaryReader(stream))
         {
-            string magic = Encoding.ASCII.GetString(br.ReadBytes(8));
+            string magic = br.ReadFixedString(8, Encoding.ASCII);
             if (magic != "r3d2aims")
             {
                 throw new InvalidFileSignatureException();

--- a/src/LeagueToolkit/Core/Legacy/IO/MapObjects/MOBFile.cs
+++ b/src/LeagueToolkit/Core/Legacy/IO/MapObjects/MOBFile.cs
@@ -1,4 +1,5 @@
 ﻿using LeagueToolkit.Utils.Exceptions;
+using LeagueToolkit.Utils.Extensions;
 using System.Text;
 
 namespace LeagueToolkit.IO.MapObjects;
@@ -41,7 +42,7 @@ public class MOBFile
     {
         using BinaryReader br = new(stream);
 
-        string magic = Encoding.ASCII.GetString(br.ReadBytes(4));
+        string magic = br.ReadFixedString(4, Encoding.ASCII);
         if (magic != "OPAM")
         {
             throw new InvalidFileSignatureException();

--- a/src/LeagueToolkit/Core/Memory/VertexBufferDescription.cs
+++ b/src/LeagueToolkit/Core/Memory/VertexBufferDescription.cs
@@ -41,7 +41,7 @@ namespace LeagueToolkit.Core.Memory
         public VertexBufferDescription(VertexBufferUsage usage, IEnumerable<VertexElement> elements)
         {
             this.Usage = usage;
-            this._elements = elements.ToArray();
+            this._elements = elements as VertexElement[] ?? elements.ToArray();
             this.DescriptionFlags = GetElementFlags(this._elements.Select(elem => elem.Name));
         }
 
@@ -50,7 +50,7 @@ namespace LeagueToolkit.Core.Memory
             VertexBufferUsage usage = (VertexBufferUsage)br.ReadUInt32();
             uint vertexElementCount = br.ReadUInt32();
 
-            return new(usage, ReadElements().ToArray());
+            return new(usage, ReadElements());
 
             IEnumerable<VertexElement> ReadElements()
             {

--- a/src/LeagueToolkit/Core/Mesh/SkinnedMesh.cs
+++ b/src/LeagueToolkit/Core/Mesh/SkinnedMesh.cs
@@ -41,7 +41,7 @@ public sealed class SkinnedMesh : IDisposable
     /// <param name="indexBuffer">The index buffer of the <see cref="SkinnedMesh"/></param>
     public SkinnedMesh(IEnumerable<SkinnedMeshRange> ranges, VertexBuffer vertexBuffer, IndexBuffer indexBuffer)
     {
-        this._ranges = ranges.ToArray();
+        this._ranges = ranges as SkinnedMeshRange[] ?? ranges.ToArray();
         this._vertexBuffer = vertexBuffer;
         this._indexBuffer = indexBuffer;
 

--- a/src/LeagueToolkit/Core/Mesh/StaticMesh.cs
+++ b/src/LeagueToolkit/Core/Mesh/StaticMesh.cs
@@ -98,9 +98,12 @@ public class StaticMesh
         if (hasVertexColors)
         {
             vertexColors = new Color[vertexCount];
+            int formatSize = Color.GetFormatSize(ColorFormat.BgraU8);
+            byte[] colorBuffer = new byte[vertexCount * formatSize];
+            br.BaseStream.ReadExact(colorBuffer);
 
             for (int i = 0; i < vertexCount; i++)
-                vertexColors[i] = br.ReadColor(ColorFormat.BgraU8);
+                vertexColors[i] = Color.Read(colorBuffer.AsSpan(i * formatSize, formatSize), ColorFormat.BgraU8);
         }
 
         Vector3 centralPoint = br.ReadVector3();
@@ -112,13 +115,22 @@ public class StaticMesh
 
         // Read face vertex colors ??
         if (flags.HasFlag(StaticMeshFlags.HasVcp))
+        {
+            int faceColorFormatSize = Color.GetFormatSize(ColorFormat.RgbU8);
+            byte[] faceColorBuffer = new byte[faceCount * 3 * faceColorFormatSize];
+            br.BaseStream.ReadExact(faceColorBuffer);
+
             for (int i = 0; i < faceCount; i++)
+            {
+                int baseIndex = i * 3 * faceColorFormatSize;
                 faces[i] = faces[i] with
                 {
-                    Color0 = br.ReadColor(ColorFormat.RgbU8),
-                    Color1 = br.ReadColor(ColorFormat.RgbU8),
-                    Color2 = br.ReadColor(ColorFormat.RgbU8)
+                    Color0 = Color.Read(faceColorBuffer.AsSpan(baseIndex, faceColorFormatSize), ColorFormat.RgbU8),
+                    Color1 = Color.Read(faceColorBuffer.AsSpan(baseIndex + faceColorFormatSize, faceColorFormatSize), ColorFormat.RgbU8),
+                    Color2 = Color.Read(faceColorBuffer.AsSpan(baseIndex + 2 * faceColorFormatSize, faceColorFormatSize), ColorFormat.RgbU8)
                 };
+            }
+        }
 
         return hasVertexColors switch
         {

--- a/src/LeagueToolkit/Core/Mesh/StaticMesh.cs
+++ b/src/LeagueToolkit/Core/Mesh/StaticMesh.cs
@@ -32,8 +32,8 @@ public class StaticMesh
 
         this.Name = name;
 
-        this._vertices = vertices.ToArray();
-        this._faces = faces.ToArray();
+        this._vertices = vertices as Vector3[] ?? vertices.ToArray();
+        this._faces = faces as StaticMeshFace[] ?? faces.ToArray();
 
         this.HasVertexColors = false;
     }
@@ -54,9 +54,9 @@ public class StaticMesh
 
         this.HasVertexColors = true;
 
-        this._vertices = vertices.ToArray();
-        this._vertexColors = vertexColors.ToArray();
-        this._faces = faces.ToArray();
+        this._vertices = vertices as Vector3[] ?? vertices.ToArray();
+        this._vertexColors = vertexColors as Color[] ?? vertexColors.ToArray();
+        this._faces = faces as StaticMeshFace[] ?? faces.ToArray();
 
         if (this._vertices.Length != this._vertexColors.Length)
             ThrowHelper.ThrowArgumentException("Vertex colors count must match vertices count");
@@ -66,7 +66,7 @@ public class StaticMesh
     {
         using BinaryReader br = new(stream);
 
-        string magic = Encoding.ASCII.GetString(br.ReadBytes(8));
+        string magic = br.ReadFixedString(8, Encoding.ASCII);
         if (magic is not "r3d2Mesh")
             throw new InvalidFileSignatureException();
 

--- a/src/LeagueToolkit/Core/Mesh/StaticMeshFace.cs
+++ b/src/LeagueToolkit/Core/Mesh/StaticMeshFace.cs
@@ -3,6 +3,8 @@ using LeagueToolkit.Core.Primitives;
 using LeagueToolkit.Utils.Extensions;
 using System.Globalization;
 using System.Numerics;
+using System.Runtime.InteropServices;
+using System.Text;
 
 namespace LeagueToolkit.Core.Mesh;
 
@@ -52,20 +54,17 @@ public readonly struct StaticMeshFace
 
     internal static StaticMeshFace ReadBinary(BinaryReader br)
     {
-        // indices are 16-bit internally
-        (ushort, ushort, ushort) indices = ((ushort)br.ReadUInt32(), (ushort)br.ReadUInt32(), (ushort)br.ReadUInt32());
+        Span<byte> buffer = stackalloc byte[12 + 64 + 24]; // 3*uint32 + 64 (material) + 6*float32
+        br.ReadExact(buffer);
 
-        string material = br.ReadPaddedString(64);
+        ReadOnlySpan<uint> indicesBuffer = MemoryMarshal.Cast<byte, uint>(buffer.Slice(0, 12));
+        (ushort, ushort, ushort) indices = ((ushort)indicesBuffer[0], (ushort)indicesBuffer[1], (ushort)indicesBuffer[2]);
 
-        ReadOnlySpan<float> uvs =
-            stackalloc float[] {
-                br.ReadSingle(),
-                br.ReadSingle(),
-                br.ReadSingle(),
-                br.ReadSingle(),
-                br.ReadSingle(),
-                br.ReadSingle()
-            };
+        ReadOnlySpan<byte> materialBuffer = buffer.Slice(12, 64);
+        int nullIndex = materialBuffer.IndexOf((byte)0);
+        string material = Encoding.UTF8.GetString(nullIndex == -1 ? materialBuffer : materialBuffer.Slice(0, nullIndex));
+
+        ReadOnlySpan<float> uvs = MemoryMarshal.Cast<byte, float>(buffer.Slice(12 + 64));
 
         return new(material, indices, (new(uvs[0], uvs[3]), new(uvs[1], uvs[4]), new(uvs[2], uvs[5])));
     }

--- a/src/LeagueToolkit/Core/Meta/BinTree.cs
+++ b/src/LeagueToolkit/Core/Meta/BinTree.cs
@@ -12,6 +12,17 @@ namespace LeagueToolkit.Core.Meta;
 public sealed class BinTree
 {
     /// <summary>
+    /// Compares this property bin with another property bin.
+    /// </summary>
+    /// <param name="other">The property bin representing the new state</param>
+    /// <returns>The object graph differences between both property bins</returns>
+    public BinTreeDiff Diff(BinTree other)
+    {
+        Guard.IsNotNull(other, nameof(other));
+        return BinTreeDiffer.Diff(this, other);
+    }
+
+    /// <summary>
     /// Gets a value indicating whether the property bin is an override
     /// </summary>
     public bool IsOverride { get; private set; }

--- a/src/LeagueToolkit/Core/Meta/BinTree.cs
+++ b/src/LeagueToolkit/Core/Meta/BinTree.cs
@@ -1,6 +1,7 @@
 ﻿using CommunityToolkit.Diagnostics;
 using CommunityToolkit.HighPerformance;
 using LeagueToolkit.Utils.Exceptions;
+using LeagueToolkit.Utils.Extensions;
 using System.Text;
 
 namespace LeagueToolkit.Core.Meta;
@@ -61,7 +62,7 @@ public sealed class BinTree
     {
         using BinaryReader br = new(stream, Encoding.UTF8, true);
 
-        string magic = Encoding.ASCII.GetString(br.ReadBytes(4));
+        string magic = br.ReadFixedString(4, Encoding.ASCII);
         if (magic != "PROP" && magic != "PTCH")
             throw new InvalidFileSignatureException();
 
@@ -77,7 +78,7 @@ public sealed class BinTree
             // and set the original file as a dependency
             uint maybeOverrideObjectCount = br.ReadUInt32(); // this seems to be object count of override section
 
-            magic = Encoding.ASCII.GetString(br.ReadBytes(4));
+            magic = br.ReadFixedString(4, Encoding.ASCII);
             if (magic is not "PROP")
                 throw new InvalidFileSignatureException("Expected PROP section after PTCH, got: " + magic);
         }
@@ -91,7 +92,10 @@ public sealed class BinTree
         {
             uint dependencyCount = br.ReadUInt32();
             for (int i = 0; i < dependencyCount; i++)
-                this.Dependencies.Add(Encoding.ASCII.GetString(br.ReadBytes(br.ReadInt16())));
+            {
+                int length = br.ReadInt16();
+                this.Dependencies.Add(br.ReadFixedString(length, Encoding.ASCII));
+            }
         }
 
         // Read object classes

--- a/src/LeagueToolkit/Core/Meta/BinTreeDiff.cs
+++ b/src/LeagueToolkit/Core/Meta/BinTreeDiff.cs
@@ -1,0 +1,196 @@
+namespace LeagueToolkit.Core.Meta;
+
+/// <summary>
+/// Describes how an element changed between two property bins.
+/// </summary>
+public enum BinTreeDiffKind
+{
+    Added,
+    Removed,
+    Modified
+}
+
+/// <summary>
+/// Represents the object graph differences between two property bins.
+/// </summary>
+public sealed class BinTreeDiff
+{
+    /// <summary>
+    /// Gets the object differences, ordered by object path hash.
+    /// </summary>
+    public IReadOnlyList<BinTreeObjectDiff> Objects { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether both property bins contain equal object graphs.
+    /// </summary>
+    public bool IsEmpty => this.Objects.Count is 0;
+
+    internal BinTreeDiff(IReadOnlyList<BinTreeObjectDiff> objects) => this.Objects = objects;
+}
+
+/// <summary>
+/// Represents a semantic change to an object in a property bin.
+/// </summary>
+public abstract class BinTreeObjectDiff
+{
+    /// <summary>
+    /// Gets the kind of change.
+    /// </summary>
+    public abstract BinTreeDiffKind Kind { get; }
+
+    /// <summary>
+    /// Gets the path hash of the changed object.
+    /// </summary>
+    public uint PathHash { get; }
+
+    private protected BinTreeObjectDiff(uint pathHash) => this.PathHash = pathHash;
+}
+
+/// <summary>
+/// Represents an object added to a property bin.
+/// </summary>
+public sealed class AddedBinTreeObjectDiff : BinTreeObjectDiff
+{
+    /// <inheritdoc/>
+    public override BinTreeDiffKind Kind => BinTreeDiffKind.Added;
+
+    /// <summary>
+    /// Gets the added object.
+    /// </summary>
+    public BinTreeObject Object { get; }
+
+    internal AddedBinTreeObjectDiff(BinTreeObject treeObject) : base(treeObject.PathHash) => this.Object = treeObject;
+}
+
+/// <summary>
+/// Represents an object removed from a property bin.
+/// </summary>
+public sealed class RemovedBinTreeObjectDiff : BinTreeObjectDiff
+{
+    /// <inheritdoc/>
+    public override BinTreeDiffKind Kind => BinTreeDiffKind.Removed;
+
+    /// <summary>
+    /// Gets the removed object.
+    /// </summary>
+    public BinTreeObject Object { get; }
+
+    internal RemovedBinTreeObjectDiff(BinTreeObject treeObject) : base(treeObject.PathHash) => this.Object = treeObject;
+}
+
+/// <summary>
+/// Represents an object modified between two property bins.
+/// </summary>
+public sealed class ModifiedBinTreeObjectDiff : BinTreeObjectDiff
+{
+    /// <inheritdoc/>
+    public override BinTreeDiffKind Kind => BinTreeDiffKind.Modified;
+
+    /// <summary>
+    /// Gets the object before the modification.
+    /// </summary>
+    public BinTreeObject OldObject { get; }
+
+    /// <summary>
+    /// Gets the object after the modification.
+    /// </summary>
+    public BinTreeObject NewObject { get; }
+
+    /// <summary>
+    /// Gets the property differences, ordered by property path.
+    /// </summary>
+    public IReadOnlyList<BinTreePropertyDiff> Properties { get; }
+
+    internal ModifiedBinTreeObjectDiff(
+        BinTreeObject oldObject,
+        BinTreeObject newObject,
+        IReadOnlyList<BinTreePropertyDiff> properties
+    ) : base(oldObject.PathHash)
+    {
+        this.OldObject = oldObject;
+        this.NewObject = newObject;
+        this.Properties = properties;
+    }
+}
+
+/// <summary>
+/// Represents a semantic change to a property. <see cref="Path"/> contains property name hashes
+/// from the object root to the changed property.
+/// </summary>
+public abstract class BinTreePropertyDiff
+{
+    /// <summary>
+    /// Gets the kind of change.
+    /// </summary>
+    public abstract BinTreeDiffKind Kind { get; }
+
+    /// <summary>
+    /// Gets the property name hashes from the object root to the changed property.
+    /// </summary>
+    public IReadOnlyList<uint> Path { get; }
+
+    private protected BinTreePropertyDiff(IReadOnlyList<uint> path) => this.Path = path;
+}
+
+/// <summary>
+/// Represents a property added to an object.
+/// </summary>
+public sealed class AddedBinTreePropertyDiff : BinTreePropertyDiff
+{
+    /// <inheritdoc/>
+    public override BinTreeDiffKind Kind => BinTreeDiffKind.Added;
+
+    /// <summary>
+    /// Gets the added property.
+    /// </summary>
+    public BinTreeProperty Property { get; }
+
+    internal AddedBinTreePropertyDiff(IReadOnlyList<uint> path, BinTreeProperty property) : base(path) =>
+        this.Property = property;
+}
+
+/// <summary>
+/// Represents a property removed from an object.
+/// </summary>
+public sealed class RemovedBinTreePropertyDiff : BinTreePropertyDiff
+{
+    /// <inheritdoc/>
+    public override BinTreeDiffKind Kind => BinTreeDiffKind.Removed;
+
+    /// <summary>
+    /// Gets the removed property.
+    /// </summary>
+    public BinTreeProperty Property { get; }
+
+    internal RemovedBinTreePropertyDiff(IReadOnlyList<uint> path, BinTreeProperty property) : base(path) =>
+        this.Property = property;
+}
+
+/// <summary>
+/// Represents a property modified between two objects.
+/// </summary>
+public sealed class ModifiedBinTreePropertyDiff : BinTreePropertyDiff
+{
+    /// <inheritdoc/>
+    public override BinTreeDiffKind Kind => BinTreeDiffKind.Modified;
+
+    /// <summary>
+    /// Gets the property before the modification.
+    /// </summary>
+    public BinTreeProperty OldProperty { get; }
+
+    /// <summary>
+    /// Gets the property after the modification.
+    /// </summary>
+    public BinTreeProperty NewProperty { get; }
+
+    internal ModifiedBinTreePropertyDiff(
+        IReadOnlyList<uint> path,
+        BinTreeProperty oldProperty,
+        BinTreeProperty newProperty
+    ) : base(path)
+    {
+        this.OldProperty = oldProperty;
+        this.NewProperty = newProperty;
+    }
+}

--- a/src/LeagueToolkit/Core/Meta/BinTreeDiffer.cs
+++ b/src/LeagueToolkit/Core/Meta/BinTreeDiffer.cs
@@ -1,0 +1,77 @@
+using LeagueToolkit.Core.Meta.Properties;
+
+namespace LeagueToolkit.Core.Meta;
+
+internal static class BinTreeDiffer
+{
+    public static BinTreeDiff Diff(BinTree oldTree, BinTree newTree)
+    {
+        List<BinTreeObjectDiff> objectDiffs = new();
+        foreach (uint pathHash in oldTree.Objects.Keys.Union(newTree.Objects.Keys).Order())
+        {
+            bool hasOldObject = oldTree.Objects.TryGetValue(pathHash, out BinTreeObject oldObject);
+            bool hasNewObject = newTree.Objects.TryGetValue(pathHash, out BinTreeObject newObject);
+
+            if (!hasOldObject)
+            {
+                objectDiffs.Add(new AddedBinTreeObjectDiff(newObject));
+                continue;
+            }
+
+            if (!hasNewObject)
+            {
+                objectDiffs.Add(new RemovedBinTreeObjectDiff(oldObject));
+                continue;
+            }
+
+            List<BinTreePropertyDiff> propertyDiffs = new();
+            DiffProperties(oldObject.Properties, newObject.Properties, Array.Empty<uint>(), propertyDiffs);
+
+            if (oldObject.ClassHash != newObject.ClassHash || propertyDiffs.Count is not 0)
+                objectDiffs.Add(new ModifiedBinTreeObjectDiff(oldObject, newObject, propertyDiffs));
+        }
+
+        return new BinTreeDiff(objectDiffs);
+    }
+
+    private static void DiffProperties(
+        IReadOnlyDictionary<uint, BinTreeProperty> oldProperties,
+        IReadOnlyDictionary<uint, BinTreeProperty> newProperties,
+        IReadOnlyList<uint> parentPath,
+        ICollection<BinTreePropertyDiff> differences
+    )
+    {
+        foreach (uint nameHash in oldProperties.Keys.Union(newProperties.Keys).Order())
+        {
+            bool hasOldProperty = oldProperties.TryGetValue(nameHash, out BinTreeProperty oldProperty);
+            bool hasNewProperty = newProperties.TryGetValue(nameHash, out BinTreeProperty newProperty);
+            uint[] path = parentPath.Append(nameHash).ToArray();
+
+            if (!hasOldProperty)
+            {
+                differences.Add(new AddedBinTreePropertyDiff(path, newProperty));
+                continue;
+            }
+
+            if (!hasNewProperty)
+            {
+                differences.Add(new RemovedBinTreePropertyDiff(path, oldProperty));
+                continue;
+            }
+
+            if (oldProperty.Equals(newProperty))
+                continue;
+
+            if (oldProperty.Type == newProperty.Type
+                && oldProperty is BinTreeStruct oldStruct
+                && newProperty is BinTreeStruct newStruct
+                && oldStruct.ClassHash == newStruct.ClassHash)
+            {
+                DiffProperties(oldStruct.Properties, newStruct.Properties, path, differences);
+                continue;
+            }
+
+            differences.Add(new ModifiedBinTreePropertyDiff(path, oldProperty, newProperty));
+        }
+    }
+}

--- a/src/LeagueToolkit/Core/Meta/Properties/BinTreeContainer.cs
+++ b/src/LeagueToolkit/Core/Meta/Properties/BinTreeContainer.cs
@@ -111,7 +111,8 @@ public class BinTreeContainer : BinTreeProperty
         if (other is not BinTreeContainer otherContainer)
             return false;
 
-        return this.Elements.SequenceEqual(otherContainer.Elements);
+        return this.ElementType == otherContainer.ElementType
+            && this.Elements.SequenceEqual(otherContainer.Elements);
     }
 
     private string GetDebuggerDisplay() => string.Format("Container<{0}>", this.ElementType);

--- a/src/LeagueToolkit/Core/Meta/Properties/BinTreeOptional.cs
+++ b/src/LeagueToolkit/Core/Meta/Properties/BinTreeOptional.cs
@@ -76,6 +76,6 @@ public sealed class BinTreeOptional : BinTreeProperty
         if (other is not BinTreeOptional optional)
             return false;
 
-        return this.Value.Equals(optional.Value);
+        return this.ValueType == optional.ValueType && Equals(this.Value, optional.Value);
     }
 }

--- a/src/LeagueToolkit/Core/Meta/Properties/BinTreeUnorderedContainer.cs
+++ b/src/LeagueToolkit/Core/Meta/Properties/BinTreeUnorderedContainer.cs
@@ -31,6 +31,7 @@ public sealed class BinTreeUnorderedContainer : BinTreeContainer
         if (other is not BinTreeUnorderedContainer unorderedContainer)
             return false;
 
-        return this.Elements.SequenceEqual(unorderedContainer.Elements);
+        return this.ElementType == unorderedContainer.ElementType
+            && this.Elements.SequenceEqual(unorderedContainer.Elements);
     }
 }

--- a/src/LeagueToolkit/Core/Wad/WadBuilder.cs
+++ b/src/LeagueToolkit/Core/Wad/WadBuilder.cs
@@ -111,7 +111,9 @@ public static class WadBuilder
         if (chunkCompression is WadChunkCompression.None)
             return fileStream;
 
-        MemoryStream compressedStream = new();
+        // Pre-size the memory stream to avoid early redundant resizing.
+        // Even if compressed data is smaller, it's better than starting at 0.
+        MemoryStream compressedStream = new((int)fileStream.Length);
         using Stream compressionStream = chunkCompression switch
         {
             WadChunkCompression.GZip => new GZipStream(compressedStream, CompressionMode.Compress),

--- a/src/LeagueToolkit/Core/Wad/WadChunk.cs
+++ b/src/LeagueToolkit/Core/Wad/WadChunk.cs
@@ -1,4 +1,6 @@
-﻿namespace LeagueToolkit.Core.Wad;
+﻿using System.Buffers.Binary;
+
+namespace LeagueToolkit.Core.Wad;
 
 /// <summary>
 /// Represents a file entry in a <see cref="WadFile"/>
@@ -47,6 +49,11 @@ public readonly struct WadChunk
     /// </summary>
     public int StartSubChunk { get; }
 
+    /// <summary>
+    /// Gets the chunk checksum
+    /// </summary>
+    public ulong Checksum => this._checksum;
+
     private readonly ulong _checksum;
 
     internal WadChunk(
@@ -77,43 +84,11 @@ public readonly struct WadChunk
 
     internal static WadChunk Read(BinaryReader br, byte major)
     {
-        ulong xxhash = br.ReadUInt64();
+        int size = major >= 2 ? TOC_SIZE_V3 : 24;
+        Span<byte> buffer = stackalloc byte[size];
+        br.ReadExactly(buffer);
 
-        long dataOffset = br.ReadUInt32();
-        int compressedSize = br.ReadInt32();
-        int uncompressedSize = br.ReadInt32();
-
-        byte type_subChunkCount = br.ReadByte();
-        int subChunkCount = type_subChunkCount >> 4;
-        WadChunkCompression chunkCompression = (WadChunkCompression)(type_subChunkCount & 0xF);
-
-        bool isDuplicated = br.ReadBoolean();
-        ushort startSubChunk = br.ReadUInt16();
-        ulong checksum = major switch
-        {
-            >= 2 => br.ReadUInt64(),
-            _ => 0
-        };
-
-        //if (this.Type == WadEntryType.FileRedirection)
-        //{
-        //    long currentPosition = br.BaseStream.Position;
-        //    br.BaseStream.Seek(this._dataOffset, SeekOrigin.Begin);
-        //    this.FileRedirection = Encoding.ASCII.GetString(br.ReadBytes(br.ReadInt32()));
-        //    br.BaseStream.Seek(currentPosition, SeekOrigin.Begin);
-        //}
-
-        return new(
-            xxhash,
-            dataOffset,
-            compressedSize,
-            uncompressedSize,
-            chunkCompression,
-            isDuplicated,
-            subChunkCount,
-            startSubChunk,
-            checksum
-        );
+        return Read(buffer, major);
     }
 
     internal void Write(BinaryWriter bw)
@@ -126,6 +101,34 @@ public readonly struct WadChunk
         bw.Write(this.IsDuplicated);
         bw.Write((ushort)0);
         bw.Write(this._checksum);
+    }
+
+    internal static WadChunk Read(ReadOnlySpan<byte> entry, byte major)
+    {
+        ulong xxhash = BinaryPrimitives.ReadUInt64LittleEndian(entry[..8]);
+        long dataOffset = BinaryPrimitives.ReadUInt32LittleEndian(entry[8..12]);
+        int compressedSize = BinaryPrimitives.ReadInt32LittleEndian(entry[12..16]);
+        int uncompressedSize = BinaryPrimitives.ReadInt32LittleEndian(entry[16..20]);
+
+        byte type_subChunkCount = entry[20];
+        int subChunkCount = type_subChunkCount >> 4;
+        WadChunkCompression chunkCompression = (WadChunkCompression)(type_subChunkCount & 0xF);
+
+        bool isDuplicated = entry[21] != 0;
+        ushort startSubChunk = BinaryPrimitives.ReadUInt16LittleEndian(entry[22..24]);
+        ulong checksum = major >= 2 ? BinaryPrimitives.ReadUInt64LittleEndian(entry[24..32]) : 0;
+
+        return new(
+            xxhash,
+            dataOffset,
+            compressedSize,
+            uncompressedSize,
+            chunkCompression,
+            isDuplicated,
+            subChunkCount,
+            startSubChunk,
+            checksum
+        );
     }
 }
 

--- a/src/LeagueToolkit/Core/Wad/WadFile.cs
+++ b/src/LeagueToolkit/Core/Wad/WadFile.cs
@@ -93,9 +93,16 @@ public sealed class WadFile : IDisposable
         // Read chunks
         int chunkCount = br.ReadInt32();
         this._chunks = new(chunkCount);
+
+        int entrySize = major >= 2 ? WadChunk.TOC_SIZE_V3 : 24;
+        using var tocOwner = MemoryOwner<byte>.Allocate(chunkCount * entrySize);
+        br.ReadExactly(tocOwner.Span);
+        ReadOnlySpan<byte> tocSpan = tocOwner.Span;
+
         for (int i = 0; i < chunkCount; i++)
         {
-            WadChunk chunk = WadChunk.Read(br, major);
+            ReadOnlySpan<byte> entry = tocSpan.Slice(i * entrySize, entrySize);
+            WadChunk chunk = WadChunk.Read(entry, major);
 
             if (!this._chunks.TryAdd(chunk.PathHash, chunk))
                 ThrowHelper.ThrowInvalidDataException($"Tried to read a chunk which already exists: {chunk.PathHash}");

--- a/src/LeagueToolkit/Core/Wad/WadFile.cs
+++ b/src/LeagueToolkit/Core/Wad/WadFile.cs
@@ -125,6 +125,56 @@ public sealed class WadFile : IDisposable
         }
     }
 
+    /// <summary>
+    /// Reads the WAD file header to extract the chunk count without instantiating a <see cref="WadFile"/>.
+    /// </summary>
+    /// <remarks>
+    /// Significantly cheaper than opening the full file and parsing the chunk table, which is
+    /// critical when counting chunks across thousands of WADs (e.g. comparator initialization).
+    /// Mirrors the header parsing of the public constructor but stops before the chunk table is loaded.
+    /// </remarks>
+    /// <param name="path">The path of the WAD file to read</param>
+    /// <returns>The chunk count if the header was parsed successfully; <c>-1</c> on any failure</returns>
+    public static int GetChunkCount(string path)
+    {
+        try
+        {
+            using FileStream fs = File.OpenRead(path);
+            using BinaryReader br = new(fs, Encoding.UTF8, true);
+
+            string magic = Encoding.ASCII.GetString(br.ReadBytes(2));
+            if (magic is not "RW")
+                return -1;
+
+            byte major = br.ReadByte();
+            br.ReadByte(); // minor
+            if (major > 3)
+                return -1;
+
+            if (major is 2)
+            {
+                br.ReadByte(); // ecdsaLength
+                br.BaseStream.Seek(83 + 8, SeekOrigin.Current); // ECDSA signature + dataChecksum
+            }
+            else if (major is 3)
+            {
+                br.BaseStream.Seek(256 + 8, SeekOrigin.Current); // ECDSA signature + dataChecksum
+            }
+
+            if (major is 1 or 2)
+            {
+                br.ReadUInt16(); // tocStartOffset
+                br.ReadUInt16(); // tocFileEntrySize
+            }
+
+            return br.ReadInt32();
+        }
+        catch
+        {
+            return -1;
+        }
+    }
+
     internal void WriteDescriptor(Stream stream)
     {
         using BinaryWriter bw = new(stream, Encoding.UTF8, true);

--- a/src/LeagueToolkit/Utils/Extensions/BinaryReaderExtensions.cs
+++ b/src/LeagueToolkit/Utils/Extensions/BinaryReaderExtensions.cs
@@ -59,6 +59,8 @@ internal static class BinaryReaderColorExtensions
         return new(position, radius);
     }
 
+    public static string ReadSizedString(this BinaryReader reader) => ReadSizedString(reader, Encoding.UTF8);
+
     public static string ReadSizedString(this BinaryReader reader, Encoding encoding)
     {
         int length = reader.ReadInt32();

--- a/src/LeagueToolkit/Utils/Extensions/BinaryReaderExtensions.cs
+++ b/src/LeagueToolkit/Utils/Extensions/BinaryReaderExtensions.cs
@@ -59,11 +59,34 @@ internal static class BinaryReaderColorExtensions
         return new(position, radius);
     }
 
-    public static string ReadSizedString(this BinaryReader reader) =>
-        Encoding.UTF8.GetString(reader.ReadBytes(reader.ReadInt32()));
+    public static string ReadSizedString(this BinaryReader reader) => ReadSizedString(reader, Encoding.UTF8);
 
-    public static string ReadPaddedString(this BinaryReader reader, int length) =>
-        Encoding.UTF8.GetString(reader.ReadBytes(length).TakeWhile(b => !b.Equals(0)).ToArray());
+    public static string ReadSizedString(this BinaryReader reader, Encoding encoding)
+    {
+        int length = reader.ReadInt32();
+        if (length == 0) return string.Empty;
+
+        Span<byte> buffer = length <= 1024 ? stackalloc byte[length] : new byte[length];
+        reader.BaseStream.ReadExact(buffer);
+        return encoding.GetString(buffer);
+    }
+
+    public static string ReadFixedString(this BinaryReader reader, int length, Encoding encoding)
+    {
+        if (length == 0) return string.Empty;
+
+        Span<byte> buffer = length <= 1024 ? stackalloc byte[length] : new byte[length];
+        reader.BaseStream.ReadExact(buffer);
+        return encoding.GetString(buffer);
+    }
+
+    public static string ReadPaddedString(this BinaryReader reader, int length)
+    {
+        Span<byte> buffer = length <= 1024 ? stackalloc byte[length] : new byte[length];
+        reader.BaseStream.ReadExact(buffer);
+        int nullIndex = buffer.IndexOf((byte)0);
+        return Encoding.UTF8.GetString(nullIndex == -1 ? buffer : buffer.Slice(0, nullIndex));
+    }
 
     public static string ReadNullTerminatedString(this BinaryReader reader)
     {

--- a/src/LeagueToolkit/Utils/Extensions/BinaryReaderExtensions.cs
+++ b/src/LeagueToolkit/Utils/Extensions/BinaryReaderExtensions.cs
@@ -59,12 +59,10 @@ internal static class BinaryReaderColorExtensions
         return new(position, radius);
     }
 
-    public static string ReadSizedString(this BinaryReader reader) => ReadSizedString(reader, Encoding.UTF8);
-
     public static string ReadSizedString(this BinaryReader reader, Encoding encoding)
     {
         int length = reader.ReadInt32();
-        if (length == 0) return string.Empty;
+        if (length <= 0) return string.Empty;
 
         Span<byte> buffer = length <= 1024 ? stackalloc byte[length] : new byte[length];
         reader.BaseStream.ReadExact(buffer);
@@ -73,7 +71,7 @@ internal static class BinaryReaderColorExtensions
 
     public static string ReadFixedString(this BinaryReader reader, int length, Encoding encoding)
     {
-        if (length == 0) return string.Empty;
+        if (length <= 0) return string.Empty;
 
         Span<byte> buffer = length <= 1024 ? stackalloc byte[length] : new byte[length];
         reader.BaseStream.ReadExact(buffer);
@@ -82,6 +80,8 @@ internal static class BinaryReaderColorExtensions
 
     public static string ReadPaddedString(this BinaryReader reader, int length)
     {
+        if (length <= 0) return string.Empty;
+
         Span<byte> buffer = length <= 1024 ? stackalloc byte[length] : new byte[length];
         reader.BaseStream.ReadExact(buffer);
         int nullIndex = buffer.IndexOf((byte)0);
@@ -90,19 +90,13 @@ internal static class BinaryReaderColorExtensions
 
     public static string ReadNullTerminatedString(this BinaryReader reader)
     {
-        string returnString = "";
-
+        var builder = new StringBuilder();
         while (true)
         {
-            char c = reader.ReadChar();
-            if (c == 0)
-            {
-                break;
-            }
-
-            returnString += c;
+            byte b = reader.ReadByte();
+            if (b == 0) break;
+            builder.Append((char)b);
         }
-
-        return returnString;
+        return builder.ToString();
     }
 }


### PR DESCRIPTION
 ### Summary

  Implements object graph diffing for BinTree, addressing #259. The new API detects added, removed, and modified objects
  and properties, including changes within nested structures.

  ### Key Changes

  - Added BinTree.Diff(BinTree).
  - Added strongly typed diff result models.
  - Added recursive comparison for Struct and Embedded properties.
  - Added deterministic ordering by object and property hashes.
  - Fixed null handling in BinTreeOptional.Equals.
  - Fixed container equality to account for ElementType.
  - Added regression tests covering object, property, nested structure, optional, and container changes.