### PR TITLE
feat(bintree): Implement diffing

### DIFF
--- a/src/LeagueToolkit.Tests/Core/Meta/BinTreeDiffTests.cs
+++ b/src/LeagueToolkit.Tests/Core/Meta/BinTreeDiffTests.cs
@@ -1,0 +1,116 @@
+using LeagueToolkit.Core.Meta;
+using LeagueToolkit.Core.Meta.Properties;
+
+namespace LeagueToolkit.Tests.Core.Meta;
+
+public class BinTreeDiffTests
+{
+    [Fact]
+    public void Should_Return_Empty_Diff_For_Equal_Trees()
+    {
+        BinTree oldTree = CreateTree(new BinTreeString(0x10, "same"));
+        BinTree newTree = CreateTree(new BinTreeString(0x10, "same"));
+
+        BinTreeDiff diff = oldTree.Diff(newTree);
+
+        Assert.True(diff.IsEmpty);
+    }
+
+    [Fact]
+    public void Should_Report_Added_And_Removed_Objects_In_Hash_Order()
+    {
+        BinTree oldTree = new(new[] { new BinTreeObject(0x20, 1, Array.Empty<BinTreeProperty>()) }, Array.Empty<string>());
+        BinTree newTree = new(new[] { new BinTreeObject(0x10, 1, Array.Empty<BinTreeProperty>()) }, Array.Empty<string>());
+
+        BinTreeDiff diff = oldTree.Diff(newTree);
+
+        Assert.Collection(
+            diff.Objects,
+            change =>
+            {
+                Assert.Equal(BinTreeDiffKind.Added, change.Kind);
+                Assert.Equal(0x10u, change.PathHash);
+            },
+            change =>
+            {
+                Assert.Equal(BinTreeDiffKind.Removed, change.Kind);
+                Assert.Equal(0x20u, change.PathHash);
+            }
+        );
+    }
+
+    [Fact]
+    public void Should_Report_Changed_Object_Class()
+    {
+        BinTree oldTree = new(new[] { new BinTreeObject(1, 0x10, Array.Empty<BinTreeProperty>()) }, Array.Empty<string>());
+        BinTree newTree = new(new[] { new BinTreeObject(1, 0x20, Array.Empty<BinTreeProperty>()) }, Array.Empty<string>());
+
+        ModifiedBinTreeObjectDiff change = Assert.IsType<ModifiedBinTreeObjectDiff>(
+            Assert.Single(oldTree.Diff(newTree).Objects)
+        );
+
+        Assert.Equal(BinTreeDiffKind.Modified, change.Kind);
+        Assert.Empty(change.Properties);
+        Assert.Equal(0x10u, change.OldObject.ClassHash);
+        Assert.Equal(0x20u, change.NewObject.ClassHash);
+    }
+
+    [Fact]
+    public void Should_Report_Added_Removed_And_Modified_Properties()
+    {
+        BinTree oldTree = CreateTree(
+            new BinTreeString(0x10, "old"),
+            new BinTreeU32(0x30, 1)
+        );
+        BinTree newTree = CreateTree(
+            new BinTreeString(0x10, "new"),
+            new BinTreeBool(0x20, true)
+        );
+
+        ModifiedBinTreeObjectDiff objectChange = Assert.IsType<ModifiedBinTreeObjectDiff>(
+            Assert.Single(oldTree.Diff(newTree).Objects)
+        );
+
+        Assert.Collection(
+            objectChange.Properties,
+            change => Assert.Equal(BinTreeDiffKind.Modified, change.Kind),
+            change => Assert.Equal(BinTreeDiffKind.Added, change.Kind),
+            change => Assert.Equal(BinTreeDiffKind.Removed, change.Kind)
+        );
+    }
+
+    [Fact]
+    public void Should_Descend_Into_Struct_Properties()
+    {
+        BinTree oldTree = CreateTree(new BinTreeStruct(0x10, 0x100, new[] { new BinTreeString(0x20, "old") }));
+        BinTree newTree = CreateTree(new BinTreeStruct(0x10, 0x100, new[] { new BinTreeString(0x20, "new") }));
+
+        ModifiedBinTreeObjectDiff objectChange = Assert.IsType<ModifiedBinTreeObjectDiff>(
+            Assert.Single(oldTree.Diff(newTree).Objects)
+        );
+        BinTreePropertyDiff change = Assert.Single(objectChange.Properties);
+
+        Assert.Equal(new uint[] { 0x10, 0x20 }, change.Path);
+        Assert.Equal(BinTreeDiffKind.Modified, change.Kind);
+    }
+
+    [Fact]
+    public void Should_Report_Container_ElementType_Changes()
+    {
+        BinTree oldTree = CreateTree(new BinTreeContainer(0x10, BinPropertyType.U8, Array.Empty<BinTreeU8>()));
+        BinTree newTree = CreateTree(new BinTreeContainer(0x10, BinPropertyType.U32, Array.Empty<BinTreeU32>()));
+
+        ModifiedBinTreeObjectDiff objectChange = Assert.IsType<ModifiedBinTreeObjectDiff>(
+            Assert.Single(oldTree.Diff(newTree).Objects)
+        );
+        ModifiedBinTreePropertyDiff propertyChange = Assert.IsType<ModifiedBinTreePropertyDiff>(
+            Assert.Single(objectChange.Properties)
+        );
+
+        Assert.Equal(BinPropertyType.U8, ((BinTreeContainer)propertyChange.OldProperty).ElementType);
+        Assert.Equal(BinPropertyType.U32, ((BinTreeContainer)propertyChange.NewProperty).ElementType);
+    }
+
+    private static BinTree CreateTree(params BinTreeProperty[] properties) =>
+        new(new[] { new BinTreeObject(1, 2, properties) }, Array.Empty<string>());
+}

--- a/src/LeagueToolkit.Tests/Core/Meta/Properties/BinTreeContainerTests.cs
+++ b/src/LeagueToolkit.Tests/Core/Meta/Properties/BinTreeContainerTests.cs
@@ -62,6 +62,15 @@ public class BinTreeContainerTests
         }
 
         [Fact]
+        public void Should_Return_False_If_ElementType_Is_Different()
+        {
+            BinTreeContainer container1 = new(0x1, BinPropertyType.U8, Array.Empty<BinTreeU8>());
+            BinTreeContainer container2 = new(0x1, BinPropertyType.U32, Array.Empty<BinTreeU32>());
+
+            Assert.False(container1.Equals(container2));
+        }
+
+        [Fact]
         public void Should_Return_True_If_Other_Has_Same_NameHash_And_Elements()
         {
             BinTreeU8 firstElement = new(0, 1);
@@ -71,6 +80,15 @@ public class BinTreeContainerTests
             BinTreeContainer container2 = new(0x1, BinPropertyType.U8, new[] { firstElement, secondElement });
 
             Assert.True(container1.Equals(container2));
+        }
+
+        [Fact]
+        public void Unordered_Should_Return_False_If_ElementType_Is_Different()
+        {
+            BinTreeUnorderedContainer container1 = new(0x1, BinPropertyType.U8, Array.Empty<BinTreeU8>());
+            BinTreeUnorderedContainer container2 = new(0x1, BinPropertyType.U32, Array.Empty<BinTreeU32>());
+
+            Assert.False(container1.Equals(container2));
         }
     }
 }

--- a/src/LeagueToolkit.Tests/Core/Meta/Properties/BinTreeOptionalTests.cs
+++ b/src/LeagueToolkit.Tests/Core/Meta/Properties/BinTreeOptionalTests.cs
@@ -1,0 +1,49 @@
+using LeagueToolkit.Core.Meta;
+using LeagueToolkit.Core.Meta.Properties;
+
+namespace LeagueToolkit.Tests.Core.Meta.Properties;
+
+public class BinTreeOptionalTests
+{
+    public class EqualsTests
+    {
+        [Fact]
+        public void Should_Return_True_When_Both_Values_Are_Null()
+        {
+            BinTreeOptional first = new(1, null);
+            BinTreeOptional second = new(1, null);
+
+            Assert.True(first.Equals(second));
+        }
+
+        [Fact]
+        public void Should_Return_False_When_Only_One_Value_Is_Null()
+        {
+            BinTreeOptional empty = new(1, null);
+            BinTreeOptional populated = new(1, new BinTreeString(0, "value"));
+
+            Assert.False(empty.Equals(populated));
+            Assert.False(populated.Equals(empty));
+        }
+
+        [Fact]
+        public void Should_Compare_Null_Optionals_Inside_Containers()
+        {
+            BinTreeOptional firstOptional = new(0, null);
+            BinTreeOptional secondOptional = new(0, null);
+            BinTreeContainer first = new(1, BinPropertyType.Optional, new[] { firstOptional });
+            BinTreeContainer second = new(1, BinPropertyType.Optional, new[] { secondOptional });
+
+            Assert.True(first.Equals(second));
+        }
+
+        [Fact]
+        public void Should_Compare_Null_Optionals_Inside_Structs()
+        {
+            BinTreeStruct first = new(1, 2, new[] { new BinTreeOptional(3, null) });
+            BinTreeStruct second = new(1, 2, new[] { new BinTreeOptional(3, null) });
+
+            Assert.True(first.Equals(second));
+        }
+    }
+}

--- a/src/LeagueToolkit/Core/Meta/BinTree.cs
+++ b/src/LeagueToolkit/Core/Meta/BinTree.cs
@@ -11,6 +11,17 @@ namespace LeagueToolkit.Core.Meta;
 public sealed class BinTree
 {
     /// <summary>
+    /// Compares this property bin with another property bin.
+    /// </summary>
+    /// <param name="other">The property bin representing the new state</param>
+    /// <returns>The object graph differences between both property bins</returns>
+    public BinTreeDiff Diff(BinTree other)
+    {
+        Guard.IsNotNull(other, nameof(other));
+        return BinTreeDiffer.Diff(this, other);
+    }
+
+    /// <summary>
     /// Gets a value indicating whether the property bin is an override
     /// </summary>
     public bool IsOverride { get; private set; }

--- a/src/LeagueToolkit/Core/Meta/BinTreeDiff.cs
+++ b/src/LeagueToolkit/Core/Meta/BinTreeDiff.cs
@@ -1,0 +1,196 @@
+namespace LeagueToolkit.Core.Meta;
+
+/// <summary>
+/// Describes how an element changed between two property bins.
+/// </summary>
+public enum BinTreeDiffKind
+{
+    Added,
+    Removed,
+    Modified
+}
+
+/// <summary>
+/// Represents the object graph differences between two property bins.
+/// </summary>
+public sealed class BinTreeDiff
+{
+    /// <summary>
+    /// Gets the object differences, ordered by object path hash.
+    /// </summary>
+    public IReadOnlyList<BinTreeObjectDiff> Objects { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether both property bins contain equal object graphs.
+    /// </summary>
+    public bool IsEmpty => this.Objects.Count is 0;
+
+    internal BinTreeDiff(IReadOnlyList<BinTreeObjectDiff> objects) => this.Objects = objects;
+}
+
+/// <summary>
+/// Represents a semantic change to an object in a property bin.
+/// </summary>
+public abstract class BinTreeObjectDiff
+{
+    /// <summary>
+    /// Gets the kind of change.
+    /// </summary>
+    public abstract BinTreeDiffKind Kind { get; }
+
+    /// <summary>
+    /// Gets the path hash of the changed object.
+    /// </summary>
+    public uint PathHash { get; }
+
+    private protected BinTreeObjectDiff(uint pathHash) => this.PathHash = pathHash;
+}
+
+/// <summary>
+/// Represents an object added to a property bin.
+/// </summary>
+public sealed class AddedBinTreeObjectDiff : BinTreeObjectDiff
+{
+    /// <inheritdoc/>
+    public override BinTreeDiffKind Kind => BinTreeDiffKind.Added;
+
+    /// <summary>
+    /// Gets the added object.
+    /// </summary>
+    public BinTreeObject Object { get; }
+
+    internal AddedBinTreeObjectDiff(BinTreeObject treeObject) : base(treeObject.PathHash) => this.Object = treeObject;
+}
+
+/// <summary>
+/// Represents an object removed from a property bin.
+/// </summary>
+public sealed class RemovedBinTreeObjectDiff : BinTreeObjectDiff
+{
+    /// <inheritdoc/>
+    public override BinTreeDiffKind Kind => BinTreeDiffKind.Removed;
+
+    /// <summary>
+    /// Gets the removed object.
+    /// </summary>
+    public BinTreeObject Object { get; }
+
+    internal RemovedBinTreeObjectDiff(BinTreeObject treeObject) : base(treeObject.PathHash) => this.Object = treeObject;
+}
+
+/// <summary>
+/// Represents an object modified between two property bins.
+/// </summary>
+public sealed class ModifiedBinTreeObjectDiff : BinTreeObjectDiff
+{
+    /// <inheritdoc/>
+    public override BinTreeDiffKind Kind => BinTreeDiffKind.Modified;
+
+    /// <summary>
+    /// Gets the object before the modification.
+    /// </summary>
+    public BinTreeObject OldObject { get; }
+
+    /// <summary>
+    /// Gets the object after the modification.
+    /// </summary>
+    public BinTreeObject NewObject { get; }
+
+    /// <summary>
+    /// Gets the property differences, ordered by property path.
+    /// </summary>
+    public IReadOnlyList<BinTreePropertyDiff> Properties { get; }
+
+    internal ModifiedBinTreeObjectDiff(
+        BinTreeObject oldObject,
+        BinTreeObject newObject,
+        IReadOnlyList<BinTreePropertyDiff> properties
+    ) : base(oldObject.PathHash)
+    {
+        this.OldObject = oldObject;
+        this.NewObject = newObject;
+        this.Properties = properties;
+    }
+}
+
+/// <summary>
+/// Represents a semantic change to a property. <see cref="Path"/> contains property name hashes
+/// from the object root to the changed property.
+/// </summary>
+public abstract class BinTreePropertyDiff
+{
+    /// <summary>
+    /// Gets the kind of change.
+    /// </summary>
+    public abstract BinTreeDiffKind Kind { get; }
+
+    /// <summary>
+    /// Gets the property name hashes from the object root to the changed property.
+    /// </summary>
+    public IReadOnlyList<uint> Path { get; }
+
+    private protected BinTreePropertyDiff(IReadOnlyList<uint> path) => this.Path = path;
+}
+
+/// <summary>
+/// Represents a property added to an object.
+/// </summary>
+public sealed class AddedBinTreePropertyDiff : BinTreePropertyDiff
+{
+    /// <inheritdoc/>
+    public override BinTreeDiffKind Kind => BinTreeDiffKind.Added;
+
+    /// <summary>
+    /// Gets the added property.
+    /// </summary>
+    public BinTreeProperty Property { get; }
+
+    internal AddedBinTreePropertyDiff(IReadOnlyList<uint> path, BinTreeProperty property) : base(path) =>
+        this.Property = property;
+}
+
+/// <summary>
+/// Represents a property removed from an object.
+/// </summary>
+public sealed class RemovedBinTreePropertyDiff : BinTreePropertyDiff
+{
+    /// <inheritdoc/>
+    public override BinTreeDiffKind Kind => BinTreeDiffKind.Removed;
+
+    /// <summary>
+    /// Gets the removed property.
+    /// </summary>
+    public BinTreeProperty Property { get; }
+
+    internal RemovedBinTreePropertyDiff(IReadOnlyList<uint> path, BinTreeProperty property) : base(path) =>
+        this.Property = property;
+}
+
+/// <summary>
+/// Represents a property modified between two objects.
+/// </summary>
+public sealed class ModifiedBinTreePropertyDiff : BinTreePropertyDiff
+{
+    /// <inheritdoc/>
+    public override BinTreeDiffKind Kind => BinTreeDiffKind.Modified;
+
+    /// <summary>
+    /// Gets the property before the modification.
+    /// </summary>
+    public BinTreeProperty OldProperty { get; }
+
+    /// <summary>
+    /// Gets the property after the modification.
+    /// </summary>
+    public BinTreeProperty NewProperty { get; }
+
+    internal ModifiedBinTreePropertyDiff(
+        IReadOnlyList<uint> path,
+        BinTreeProperty oldProperty,
+        BinTreeProperty newProperty
+    ) : base(path)
+    {
+        this.OldProperty = oldProperty;
+        this.NewProperty = newProperty;
+    }
+}

--- a/src/LeagueToolkit/Core/Meta/BinTreeDiffer.cs
+++ b/src/LeagueToolkit/Core/Meta/BinTreeDiffer.cs
@@ -1,0 +1,77 @@
+using LeagueToolkit.Core.Meta.Properties;
+
+namespace LeagueToolkit.Core.Meta;
+
+internal static class BinTreeDiffer
+{
+    public static BinTreeDiff Diff(BinTree oldTree, BinTree newTree)
+    {
+        List<BinTreeObjectDiff> objectDiffs = new();
+        foreach (uint pathHash in oldTree.Objects.Keys.Union(newTree.Objects.Keys).Order())
+        {
+            bool hasOldObject = oldTree.Objects.TryGetValue(pathHash, out BinTreeObject oldObject);
+            bool hasNewObject = newTree.Objects.TryGetValue(pathHash, out BinTreeObject newObject);
+
+            if (!hasOldObject)
+            {
+                objectDiffs.Add(new AddedBinTreeObjectDiff(newObject));
+                continue;
+            }
+
+            if (!hasNewObject)
+            {
+                objectDiffs.Add(new RemovedBinTreeObjectDiff(oldObject));
+                continue;
+            }
+
+            List<BinTreePropertyDiff> propertyDiffs = new();
+            DiffProperties(oldObject.Properties, newObject.Properties, Array.Empty<uint>(), propertyDiffs);
+
+            if (oldObject.ClassHash != newObject.ClassHash || propertyDiffs.Count is not 0)
+                objectDiffs.Add(new ModifiedBinTreeObjectDiff(oldObject, newObject, propertyDiffs));
+        }
+
+        return new BinTreeDiff(objectDiffs);
+    }
+
+    private static void DiffProperties(
+        IReadOnlyDictionary<uint, BinTreeProperty> oldProperties,
+        IReadOnlyDictionary<uint, BinTreeProperty> newProperties,
+        IReadOnlyList<uint> parentPath,
+        ICollection<BinTreePropertyDiff> differences
+    )
+    {
+        foreach (uint nameHash in oldProperties.Keys.Union(newProperties.Keys).Order())
+        {
+            bool hasOldProperty = oldProperties.TryGetValue(nameHash, out BinTreeProperty oldProperty);
+            bool hasNewProperty = newProperties.TryGetValue(nameHash, out BinTreeProperty newProperty);
+            uint[] path = parentPath.Append(nameHash).ToArray();
+
+            if (!hasOldProperty)
+            {
+                differences.Add(new AddedBinTreePropertyDiff(path, newProperty));
+                continue;
+            }
+
+            if (!hasNewProperty)
+            {
+                differences.Add(new RemovedBinTreePropertyDiff(path, oldProperty));
+                continue;
+            }
+
+            if (oldProperty.Equals(newProperty))
+                continue;
+
+            if (oldProperty.Type == newProperty.Type
+                && oldProperty is BinTreeStruct oldStruct
+                && newProperty is BinTreeStruct newStruct
+                && oldStruct.ClassHash == newStruct.ClassHash)
+            {
+                DiffProperties(oldStruct.Properties, newStruct.Properties, path, differences);
+                continue;
+            }
+
+            differences.Add(new ModifiedBinTreePropertyDiff(path, oldProperty, newProperty));
+        }
+    }
+}

--- a/src/LeagueToolkit/Core/Meta/Properties/BinTreeContainer.cs
+++ b/src/LeagueToolkit/Core/Meta/Properties/BinTreeContainer.cs
@@ -111,7 +111,8 @@ public class BinTreeContainer : BinTreeProperty
         if (other is not BinTreeContainer otherContainer)
             return false;
 
-        return this.Elements.SequenceEqual(otherContainer.Elements);
+        return this.ElementType == otherContainer.ElementType
+            && this.Elements.SequenceEqual(otherContainer.Elements);
     }
 
     private string GetDebuggerDisplay() => string.Format("Container<{0}>", this.ElementType);

--- a/src/LeagueToolkit/Core/Meta/Properties/BinTreeOptional.cs
+++ b/src/LeagueToolkit/Core/Meta/Properties/BinTreeOptional.cs
@@ -76,6 +76,6 @@ public sealed class BinTreeOptional : BinTreeProperty
         if (other is not BinTreeOptional optional)
             return false;
 
-        return this.Value.Equals(optional.Value);
+        return this.ValueType == optional.ValueType && Equals(this.Value, optional.Value);
     }
 }

--- a/src/LeagueToolkit/Core/Meta/Properties/BinTreeUnorderedContainer.cs
+++ b/src/LeagueToolkit/Core/Meta/Properties/BinTreeUnorderedContainer.cs
@@ -31,6 +31,7 @@ public sealed class BinTreeUnorderedContainer : BinTreeContainer
         if (other is not BinTreeUnorderedContainer unorderedContainer)
             return false;
 
-        return this.Elements.SequenceEqual(unorderedContainer.Elements);
+        return this.ElementType == unorderedContainer.ElementType
+            && this.Elements.SequenceEqual(unorderedContainer.Elements);
     }
 }


### PR DESCRIPTION
 ### Summary

  Implements object graph diffing for BinTree, addressing #259. The new API detects added, removed, and modified objects
  and properties, including changes within nested structures.

  ### Key Changes

  - Added BinTree.Diff(BinTree).
  - Added strongly typed diff result models.
  - Added recursive comparison for Struct and Embedded properties.
  - Added deterministic ordering by object and property hashes.
  - Fixed null handling in BinTreeOptional.Equals.
  - Fixed container equality to account for ElementType.
  - Added regression tests covering object, property, nested structure, optional, and container changes.