### PR TITLE
feat(wad): add TryReadHeader lightweight WAD inspection

### DIFF
--- a/src/LeagueToolkit/Core/Wad/WadFile.cs
+++ b/src/LeagueToolkit/Core/Wad/WadFile.cs
@@ -1,4 +1,4 @@
-﻿using CommunityToolkit.Diagnostics;
+using CommunityToolkit.Diagnostics;
 using CommunityToolkit.HighPerformance;
 using CommunityToolkit.HighPerformance.Buffers;
 using LeagueToolkit.Hashing;
@@ -115,6 +115,63 @@ public sealed class WadFile : IDisposable
 
             if (this._chunks.TryGetValue(XxHash64Ext.Hash(subchunkTocPath), out WadChunk subchunkTocChunk))
                 this._subchunkTocMemory = LoadChunkDecompressed(subchunkTocChunk);
+        }
+    }
+
+    /// <summary>
+    /// Represents structural information extracted from a WAD file header
+    /// </summary>
+    public record struct WadHeaderInfo(byte Major, byte Minor, int ChunkCount);
+
+    /// <summary>
+    /// Attempts to read the WAD file header to extract metadata without instantiating a full <see cref="WadFile"/>.
+    /// </summary>
+    /// <remarks>
+    /// Cheaper than opening the full file and parsing the chunk table.
+    /// </remarks>
+    /// <param name="path">The path of the WAD file to read</param>
+    /// <param name="headerInfo">When this method returns, contains the parsed header info if successful; otherwise, default values</param>
+    /// <returns><c>true</c> if the header was parsed successfully; otherwise, <c>false</c></returns>
+    public static bool TryReadHeader(string path, out WadHeaderInfo headerInfo)
+    {
+        headerInfo = default;
+        try
+        {
+            using FileStream fs = File.OpenRead(path);
+            using BinaryReader br = new(fs, Encoding.UTF8, true);
+
+            string magic = Encoding.ASCII.GetString(br.ReadBytes(2));
+            if (magic is not "RW")
+                return false;
+
+            byte major = br.ReadByte();
+            byte minor = br.ReadByte();
+            if (major > 3)
+                return false;
+
+            if (major is 2)
+            {
+                br.ReadByte(); // ecdsaLength
+                br.BaseStream.Seek(83 + 8, SeekOrigin.Current); // ECDSA signature + dataChecksum
+            }
+            else if (major is 3)
+            {
+                br.BaseStream.Seek(256 + 8, SeekOrigin.Current); // ECDSA signature + dataChecksum
+            }
+
+            if (major is 1 or 2)
+            {
+                br.ReadUInt16(); // tocStartOffset
+                br.ReadUInt16(); // tocFileEntrySize
+            }
+
+            int chunkCount = br.ReadInt32();
+            headerInfo = new WadHeaderInfo(major, minor, chunkCount);
+            return true;
+        }
+        catch
+        {
+            return false;
         }
     }
 


### PR DESCRIPTION
 #### Summary

  This Pull Request introduces  WadFile.TryReadHeader , a non-allocating, lightweight static API designed to inspect
  WAD archive metadata (major version, minor version, and chunk count) directly from the file stream header.

  This avoids the memory overhead and I/O latency of instantiating a full  WadFile  object and parsing the entire
  chunk table when only basic metadata or integrity checks are required (e.g., when indexing or scanning directories
  containing numerous archives).
  
  #### Key Changes

  • Added  WadHeaderInfo  struct: A lightweight record struct containing the  Major  version,  Minor  version, and
  ChunkCount  of the WAD file.
  • Implemented  WadFile.TryReadHeader :
      • Reads the stream header, validates the  RW  magic signature, and extracts the format version.
      • Handles version-specific header layouts dynamically (including skipping ECDSA signatures and checksum offsets
      for V2/V3 formats).
      • Retrieves the chunk count directly from the header without parsing the chunk entries.
  • Adopted standard  Try  pattern: Replaces error-prone sentinel values (like returning  -1  on parsing failure)
  with a robust boolean state and  out  parameter model.