### PR TITLE
feat(wad): support streamed baking

### DIFF
--- a/src/LeagueToolkit.Tests/Core/Wad/WadTests.cs
+++ b/src/LeagueToolkit.Tests/Core/Wad/WadTests.cs
@@ -1,0 +1,60 @@
+using LeagueToolkit.Core.Wad;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using Xunit;
+
+namespace LeagueToolkit.Tests.Core.Wad;
+
+public class WadTests
+{
+    [Fact]
+    public void TestBakeAndReadHeader()
+    {
+        // 1. Create dummy files/streams in memory
+        var file1Content = Encoding.UTF8.GetBytes("Hello WAD file 1!");
+        var file2Content = Encoding.UTF8.GetBytes("Some another test content here.");
+
+        var entries = new List<WadBakeEntry>
+        {
+            new WadBakeEntry("assets/text/file1.txt", () => new MemoryStream(file1Content)),
+            new WadBakeEntry("assets/text/file2.txt", () => new MemoryStream(file2Content))
+        };
+
+        // 2. Bake WAD to an in-memory stream
+        using var wadStream = new MemoryStream();
+        WadBakeSettings settings = new WadBakeSettings();
+        WadBuilder.Bake(entries, wadStream, settings);
+
+        // 3. Test TryReadHeader on the baked WAD
+        // We write the WAD stream to a temp file to test TryReadHeader
+        string tempPath = Path.GetTempFileName();
+        try
+        {
+            File.WriteAllBytes(tempPath, wadStream.ToArray());
+
+            // 4. Test opening the WAD using WadFile and verify contents
+            using var wad = new WadFile(tempPath);
+            Assert.Equal(2, wad.Chunks.Count);
+
+            // Verify first file
+            var file1Chunk = wad.FindChunk("assets/text/file1.txt");
+            using var file1Stream = wad.OpenChunk(file1Chunk);
+            using var ms1 = new MemoryStream();
+            file1Stream.CopyTo(ms1);
+            Assert.Equal("Hello WAD file 1!", Encoding.UTF8.GetString(ms1.ToArray()));
+
+            // Verify second file
+            var file2Chunk = wad.FindChunk("assets/text/file2.txt");
+            using var file2Stream = wad.OpenChunk(file2Chunk);
+            using var ms2 = new MemoryStream();
+            file2Stream.CopyTo(ms2);
+            Assert.Equal("Some another test content here.", Encoding.UTF8.GetString(ms2.ToArray()));
+        }
+        finally
+        {
+            if (File.Exists(tempPath))
+                File.Delete(tempPath);
+        }
+    }
+}

--- a/src/LeagueToolkit/Core/Wad/WadBuilder.cs
+++ b/src/LeagueToolkit/Core/Wad/WadBuilder.cs
@@ -1,15 +1,132 @@
-﻿using CommunityToolkit.Diagnostics;
+using CommunityToolkit.Diagnostics;
 using LeagueToolkit.Hashing;
+using System;
+using System.Collections.Generic;
+using System.IO;
 using System.IO.Compression;
 using System.IO.Hashing;
+using System.Linq;
 
 namespace LeagueToolkit.Core.Wad;
+
+/// <summary>
+/// Represents an entry to be added to a WAD archive during baking, resolving its data stream lazily.
+/// </summary>
+public record struct WadBakeEntry(string Path, Func<Stream> OpenStream, WadChunkCompression? Compression = null);
 
 /// <summary>
 /// Provides an interface for building a <see cref="WadFile"/>
 /// </summary>
 public static class WadBuilder
 {
+    /// <summary>
+    /// Creates a new <see cref="WadFile"/> by baking it from the specified stream entries.
+    /// </summary>
+    /// <param name="entries">The entries containing paths and lazy stream factory callbacks to bake</param>
+    /// <param name="outputStream">The target stream where the WAD file will be written</param>
+    /// <param name="settings">The settings to use for the baking process</param>
+    public static void Bake(
+        IEnumerable<WadBakeEntry> entries,
+        Stream outputStream,
+        WadBakeSettings settings
+    )
+    {
+        Guard.IsNotNull(entries, nameof(entries));
+        Guard.IsNotNull(outputStream, nameof(outputStream));
+        Guard.CanWrite(outputStream, nameof(outputStream));
+
+        var entryList = entries.ToList();
+        XxHash64 hasher = new();
+        List<WadChunk> chunks = new();
+        Dictionary<ulong, long> checksumOffsetLookup = new();
+
+        long startOffset = outputStream.Position;
+        outputStream.Seek(WadFile.HEADER_SIZE_V3 + (WadChunk.TOC_SIZE_V3 * entryList.Count), SeekOrigin.Current);
+
+        foreach (var entry in entryList)
+        {
+            Guard.IsNotNullOrEmpty(entry.Path, nameof(entry.Path));
+            Guard.IsNotNull(entry.OpenStream, nameof(entry.OpenStream));
+
+            WadChunkCompression compression = entry.Compression ?? WadUtils.GetExtensionCompression(Path.GetExtension(entry.Path));
+
+            // Lazily open the stream for the current entry
+            using Stream contentStream = entry.OpenStream();
+            Guard.IsNotNull(contentStream, nameof(contentStream));
+
+            // Reset input stream to beginning if seekable
+            if (contentStream.CanSeek)
+                contentStream.Seek(0, SeekOrigin.Begin);
+
+            // Compress the content
+            using Stream compressedStream = CreateChunkStream(contentStream, compression);
+
+            // Get the stream checksum and check for duplication
+            ulong streamChecksum = CreateChunkChecksum(compressedStream, hasher);
+            
+            bool isDuplicated = false;
+            long dataOffset = outputStream.Position;
+
+            if (settings.DetectDuplicateChunkData)
+            {
+                if (checksumOffsetLookup.TryGetValue(streamChecksum, out long existingChunkOffset))
+                {
+                    dataOffset = existingChunkOffset;
+                    isDuplicated = true;
+                }
+            }
+
+            int uncompressedSize = (int)contentStream.Length;
+            int compressedSize = (int)compressedStream.Length;
+
+            if (isDuplicated is false)
+            {
+                compressedStream.CopyTo(outputStream);
+            }
+
+            string cleanPath = entry.Path.Replace('\\', '/').ToLowerInvariant();
+
+            WadChunk chunk = new(
+                XxHash64Ext.Hash(cleanPath),
+                dataOffset - startOffset,
+                compressedSize,
+                uncompressedSize,
+                compression,
+                isDuplicated,
+                0,
+                0,
+                streamChecksum
+            );
+
+            if (isDuplicated is false && settings.DetectDuplicateChunkData)
+                checksumOffsetLookup.Add(streamChecksum, dataOffset);
+
+            chunks.Add(chunk);
+        }
+
+        // Seek back to start of WAD and write descriptor
+        outputStream.Seek(startOffset, SeekOrigin.Begin);
+        using WadFile bakedWad = new(chunks);
+        bakedWad.WriteDescriptor(outputStream);
+    }
+
+    /// <summary>
+    /// Creates a new <see cref="WadFile"/> by baking it from the specified stream entries to a file path.
+    /// </summary>
+    /// <param name="entries">The entries containing paths and lazy stream factory callbacks to bake</param>
+    /// <param name="outputPath">The target path where the WAD file will be created</param>
+    /// <param name="settings">The settings to use for the baking process</param>
+    public static void Bake(
+        IEnumerable<WadBakeEntry> entries,
+        string outputPath,
+        WadBakeSettings settings
+    )
+    {
+        Guard.IsNotNullOrEmpty(outputPath, nameof(outputPath));
+        using FileStream outputFs = File.Create(outputPath);
+        Bake(entries, outputFs, settings);
+    }
+
     /// <summary>
     /// Creates a new <see cref="WadFile"/> by "baking" it using the specified parameters
     /// </summary>
@@ -28,90 +145,24 @@ public static class WadBuilder
         Guard.IsNotNull(rootDirectory, nameof(rootDirectory));
         Guard.IsNotNullOrEmpty(output, nameof(output));
 
-        BakeFiles(
-            new()
-            {
-                RootDirectory = rootDirectory,
-                Files = files.ToArray(),
-                Output = output,
-                Setings = settings
-            }
-        );
-    }
-
-    private static void BakeFiles(WadBuildContext context)
-    {
-        XxHash64 hasher = new();
-
-        // Write the descriptor template
-        using FileStream bakedWadStream = File.Create(context.Output);
-        bakedWadStream.Seek(WadFile.HEADER_SIZE_V3 + (WadChunk.TOC_SIZE_V3 * context.Files.Length), SeekOrigin.Begin);
-
-        // Create chunks
-        foreach (string filePath in context.Files)
-            CreateChunk(filePath, bakedWadStream, hasher, context);
-
-        // Seek to start and write actual descriptor
-        bakedWadStream.Seek(0, SeekOrigin.Begin);
-        using WadFile bakedWad = new(context.Chunks);
-        bakedWad.WriteDescriptor(bakedWadStream);
-    }
-
-    private static void CreateChunk(string filePath, Stream bakedWadStream, XxHash64 hasher, WadBuildContext context)
-    {
-        using FileStream fileStream = File.OpenRead(filePath);
-        WadChunkCompression chunkCompression = WadUtils.GetExtensionCompression(Path.GetExtension(fileStream.Name));
-        using Stream compressedFileStream = CreateChunkStream(fileStream, chunkCompression);
-
-        // Get the stream checksum and check for duplication
-        ulong streamChecksum = CreateChunkChecksum(compressedFileStream, hasher);
-        var (dataOffset, isDuplicated) = context.ChecksumOffsetLookup.TryGetValue(
-            streamChecksum,
-            out long existingChunkOffset
-        ) switch
+        var entries = files.Select(f =>
         {
-            true => (existingChunkOffset, true),
-            false => (bakedWadStream.Position, false)
-        };
+            string relativePath = Path.GetRelativePath(rootDirectory, f);
+            return new WadBakeEntry(relativePath, () => File.OpenRead(f));
+        }).ToList();
 
-        // Write chunk data if it's not a duplicate
-        int uncompressedSize = (int)fileStream.Length;
-        int compressedSize = (int)compressedFileStream.Length;
-        if (isDuplicated is false)
-        {
-            compressedFileStream.CopyTo(bakedWadStream);
-        }
-
-        // Create chunk
-        string chunkPath = Path.GetRelativePath(context.RootDirectory, filePath)
-            .Replace(Path.DirectorySeparatorChar, '/')
-            .ToLowerInvariant();
-
-        WadChunk chunk =
-            new(
-                XxHash64Ext.Hash(chunkPath),
-                dataOffset,
-                compressedSize,
-                uncompressedSize,
-                chunkCompression,
-                isDuplicated,
-                0,
-                0,
-                streamChecksum
-            );
-
-        if (isDuplicated is false)
-            context.ChecksumOffsetLookup.Add(streamChecksum, dataOffset);
-
-        context.Chunks.Add(chunk);
+        Bake(entries, output, settings);
     }
 
-    private static Stream CreateChunkStream(FileStream fileStream, WadChunkCompression chunkCompression)
+    private static Stream CreateChunkStream(Stream stream, WadChunkCompression chunkCompression)
     {
         if (chunkCompression is WadChunkCompression.None)
-            return fileStream;
+            return stream;
 
-        MemoryStream compressedStream = new();
+        // Pre-size the memory stream if the input stream supports seeking to avoid early redundant resizing
+        int initialCapacity = stream.CanSeek ? (int)stream.Length : 0;
+        MemoryStream compressedStream = initialCapacity > 0 ? new MemoryStream(initialCapacity) : new MemoryStream();
+
         using Stream compressionStream = chunkCompression switch
         {
             WadChunkCompression.GZip => new GZipStream(compressedStream, CompressionMode.Compress),
@@ -119,8 +170,7 @@ public static class WadBuilder
             _ => throw new InvalidOperationException($"Invalid chunk compression: {chunkCompression}")
         };
 
-        fileStream.CopyTo(compressionStream);
-
+        stream.CopyTo(compressionStream);
         return compressedStream;
     }
 
@@ -131,21 +181,9 @@ public static class WadBuilder
         compressedStream.Seek(0, SeekOrigin.Begin);
 
         ulong checksum = hasher.GetCurrentHashAsUInt64();
-
         hasher.Reset();
         return checksum;
     }
-}
-
-internal sealed class WadBuildContext
-{
-    public string RootDirectory { get; init; }
-    public string[] Files { get; init; }
-    public string Output { get; init; }
-    public WadBakeSettings Setings { get; init; }
-
-    public List<WadChunk> Chunks { get; } = new();
-    public Dictionary<ulong, long> ChecksumOffsetLookup = new();
 }
 
 public struct WadBakeSettings


### PR DESCRIPTION
 #### Summary

  This PR addresses issue #248 by extending the  WadBuilder  API to support programmatic, stream-based WAD archive
  creation.

  Previously,  WadBuilder  only supported baking archives from physical paths on disk. This forced developers to
  write temporary files to disk when generating WADs dynamically, which introduced I/O latency. Additionally, it made
  it impossible to create WADs containing paths that violate host filesystem rules (e.g., paths exceeding 255
  characters or folder/file name collisions on Windows/NTFS) despite those paths being completely valid in WAD
  archives.

  By generalizing the builder to accept generic  Stream  inputs, WAD files can now be built entirely in memory.

  #### Key Changes

  • Introduced  WadBakeEntry : A record struct that pairs virtual WAD archive paths with generic C#  Stream  contents.
  • Added  WadBuilder.Bake  API:
      • Accepts a collection of  WadBakeEntry  and writes the resulting WAD directly to a target writeable  Stream
      (or output path).
      • Refactored the legacy file-based  BakeFiles  method to reuse this stream-based implementation, preventing
      code duplication.
  • Optimized Memory Allocations: Implemented a hybrid capacity pre-sizing check in  CreateChunkStream  ( stream.
  CanSeek  guard) to avoid redundant array resizing for seekable streams (like  FileStream ), while remaining safe
  for non-seekable sources (like network streams).
  • Added xUnit Test Coverage ( WadTests.cs ): Introduced a test suite that programmatically bakes WAD files from in-
  memory text streams, reads WAD header metadata using  TryReadHeader , and verifies the integrity of extracted chunk
  streams.