### PR TITLE
feat(bintree): Implement pathing

### DIFF
--- a/src/LeagueToolkit.Tests/Core/Meta/BinTreeExtensionsTests.cs
+++ b/src/LeagueToolkit.Tests/Core/Meta/BinTreeExtensionsTests.cs
@@ -1,0 +1,157 @@
+using Xunit;
+using LeagueToolkit.Core.Meta;
+using LeagueToolkit.Core.Meta.Properties;
+using LeagueToolkit.Hashing;
+using System.Collections.Generic;
+
+namespace LeagueToolkit.Tests.Core.Meta;
+
+public class BinTreeExtensionsTests
+{
+    [Fact]
+    public void TestPathingTraversals()
+    {
+        // 1. Setup simple properties
+        var floatProp = new BinTreeF32(Fnv1a.HashLower("myFloat"), 3.14f);
+        var intProp = new BinTreeI32(Fnv1a.HashLower("myInt"), 42);
+
+        // 2. Setup Struct property
+        var structProps = new List<BinTreeProperty> { floatProp, intProp };
+        var structProp = new BinTreeStruct(
+            Fnv1a.HashLower("myStruct"),
+            Fnv1a.HashLower("MyStructClass"),
+            structProps
+        );
+
+        // 3. Setup Container property
+        var element1 = new BinTreeI32(0, 100);
+        var element2 = new BinTreeI32(0, 200);
+        var containerProp = new BinTreeContainer(
+            Fnv1a.HashLower("myList"),
+            BinPropertyType.I32,
+            new[] { element1, element2 }
+        );
+
+        // 4. Setup Optional property
+        var optionalInner = new BinTreeI32(Fnv1a.HashLower("optValue"), 999);
+        var optionalProp = new BinTreeOptional(
+            Fnv1a.HashLower("myOptional"),
+            optionalInner
+        );
+
+        // 5. Setup Map property
+        var key1 = new BinTreeString(0, "keyOne");
+        var val1 = new BinTreeI32(0, 111);
+        var key2 = new BinTreeString(0, "keyTwo");
+        var val2 = new BinTreeI32(0, 222);
+        var mapPairs = new List<KeyValuePair<BinTreeProperty, BinTreeProperty>>
+        {
+            KeyValuePair.Create<BinTreeProperty, BinTreeProperty>(key1, val1),
+            KeyValuePair.Create<BinTreeProperty, BinTreeProperty>(key2, val2)
+        };
+        var mapProp = new BinTreeMap(
+            Fnv1a.HashLower("myMap"),
+            BinPropertyType.String,
+            BinPropertyType.I32,
+            mapPairs
+        );
+
+        // Assemble Object 1: "Characters/Ahri/Skins/Skin0"
+        var objProperties = new List<BinTreeProperty>
+        {
+            structProp,
+            containerProp,
+            optionalProp,
+            mapProp
+        };
+        var binObj = new BinTreeObject(
+            "Characters/Ahri/Skins/Skin0",
+            "SkinData",
+            objProperties
+        );
+
+        // Assemble BinTree
+        var binTree = new BinTree(new[] { binObj }, new string[0]);
+
+        // --- TEST Traversals ---
+
+        // Test Object Direct Traversal (should fail because object itself is not a property)
+        Assert.False(binTree.TryGetProperty("Characters/Ahri/Skins/Skin0", out _));
+
+        // Test basic Struct lookup
+        Assert.True(binTree.TryGetProperty("Characters/Ahri/Skins/Skin0/myStruct/myFloat", out var res1));
+        var floatVal = Assert.IsType<BinTreeF32>(res1);
+        Assert.Equal(3.14f, floatVal.Value);
+
+        // Test Struct lookup starting from the Object directly
+        var resObj = binObj.GetProperty("myStruct/myInt");
+        var intVal = Assert.IsType<BinTreeI32>(resObj);
+        Assert.Equal(42, intVal.Value);
+
+        // Test Container index lookup
+        var resContainer = binTree.GetProperty("Characters/Ahri/Skins/Skin0/myList[1]");
+        var containerVal = Assert.IsType<BinTreeI32>(resContainer);
+        Assert.Equal(200, containerVal.Value);
+
+        // Test Optional direct name match lookup
+        var resOpt1 = binTree.GetProperty("Characters/Ahri/Skins/Skin0/myOptional/optValue");
+        var optVal1 = Assert.IsType<BinTreeI32>(resOpt1);
+        Assert.Equal(999, optVal1.Value);
+
+        // Test Map lookup by string key
+        var resMap1 = binTree.GetProperty("Characters/Ahri/Skins/Skin0/myMap/keyOne");
+        var mapVal1 = Assert.IsType<BinTreeI32>(resMap1);
+        Assert.Equal(111, mapVal1.Value);
+
+        // Test Map lookup by hash key string (keyTwo)
+        var resMap2 = binTree.GetProperty("Characters/Ahri/Skins/Skin0/myMap/keyTwo");
+        var mapVal2 = Assert.IsType<BinTreeI32>(resMap2);
+        Assert.Equal(222, mapVal2.Value);
+
+        // Test hexadecimal hash fallback lookup
+        string hexStructHash = "0x" + Fnv1a.HashLower("myStruct").ToString("X");
+        string hexFloatHash = "0x" + Fnv1a.HashLower("myFloat").ToString("X");
+        var resHex = binTree.GetProperty($"Characters/Ahri/Skins/Skin0/{hexStructHash}/{hexFloatHash}");
+        var floatValHex = Assert.IsType<BinTreeF32>(resHex);
+        Assert.Equal(3.14f, floatValHex.Value);
+
+        // Test non-existing path
+        Assert.Null(binTree.GetProperty("Characters/Ahri/Skins/Skin0/nonExisting"));
+        Assert.Null(binTree.GetProperty("Characters/Ahri/Skins/Skin0/myStruct/nonExisting"));
+        Assert.Null(binTree.GetProperty("Characters/Ahri/Skins/Skin0/myList[99]"));
+    }
+
+    [Fact]
+    public void TestRealBinFileSerialization()
+    {
+        // 1. Create a tree with a struct and simple types
+        var floatProp = new BinTreeF32(Fnv1a.HashLower("myFloat"), 9.99f);
+        var structProps = new List<BinTreeProperty> { floatProp };
+        var structProp = new BinTreeStruct(
+            Fnv1a.HashLower("myStruct"),
+            Fnv1a.HashLower("MyStructClass"),
+            structProps
+        );
+
+        var objProperties = new List<BinTreeProperty> { structProp };
+        var binObj = new BinTreeObject(
+            "Characters/Ahri/Skins/Skin0",
+            "SkinData",
+            objProperties
+        );
+        var originalTree = new BinTree(new[] { binObj }, new string[0]);
+
+        // 2. Serialize to binary stream (mimicking writing a real .bin file)
+        using var ms = new System.IO.MemoryStream();
+        originalTree.Write(ms);
+        ms.Position = 0;
+
+        // 3. Deserialize back (mimicking reading a real .bin file)
+        var loadedTree = new BinTree(ms);
+
+        // 4. Test pathing on the loaded tree
+        Assert.True(loadedTree.TryGetProperty("Characters/Ahri/Skins/Skin0/myStruct/myFloat", out var res));
+        var floatVal = Assert.IsType<BinTreeF32>(res);
+        Assert.Equal(9.99f, floatVal.Value);
+    }
+}

--- a/src/LeagueToolkit/Core/Meta/BinTreeExtensions.cs
+++ b/src/LeagueToolkit/Core/Meta/BinTreeExtensions.cs
@@ -1,0 +1,375 @@
+using LeagueToolkit.Core.Meta.Properties;
+using LeagueToolkit.Hashing;
+
+namespace LeagueToolkit.Core.Meta;
+
+/// <summary>
+/// Provides extension methods for traversing and querying <see cref="BinTree"/> properties by path.
+/// </summary>
+public static class BinTreeExtensions
+{
+    /// <summary>
+    /// Resolves a property path starting from the root of a <see cref="BinTree"/> without allocating string arrays.
+    /// </summary>
+    /// <param name="binTree">The property bin tree.</param>
+    /// <param name="path">The path to the property (e.g., "Characters/Ahri/Skins/Skin0/mResourceResolver/vfx").</param>
+    /// <returns>The resolved property, or <see langword="null"/> if not found.</returns>
+    public static BinTreeProperty GetProperty(this BinTree binTree, string path)
+    {
+        return binTree.TryGetProperty(path, out var property) ? property : null;
+    }
+
+    /// <summary>
+    /// Tries to resolve a property path starting from the root of a <see cref="BinTree"/> without allocating string arrays.
+    /// </summary>
+    /// <param name="binTree">The property bin tree.</param>
+    /// <param name="path">The path to the property.</param>
+    /// <param name="property">The resolved property if found; otherwise, <see langword="null"/>.</param>
+    /// <returns><see langword="true"/> if the property was successfully resolved; otherwise, <see langword="false"/>.</returns>
+    public static bool TryGetProperty(this BinTree binTree, string path, out BinTreeProperty property)
+    {
+        property = null;
+        if (string.IsNullOrEmpty(path))
+            return false;
+
+        ReadOnlySpan<char> pathSpan = path.AsSpan();
+
+        // 1. Find the root object by checking incremental path prefixes.
+        // League of Legends object names can contain slashes, so we search for a matching prefix.
+        BinTreeObject rootObject = null;
+        int remainingIndex = -1;
+        int currentLength = 0;
+
+        while (currentLength < pathSpan.Length)
+        {
+            // Find next separator
+            int nextSep = pathSpan.Slice(currentLength).IndexOfAny('/', '\\');
+            if (nextSep == -1)
+            {
+                currentLength = pathSpan.Length;
+            }
+            else
+            {
+                currentLength += nextSep;
+            }
+
+            ReadOnlySpan<char> prefixSpan = pathSpan.Slice(0, currentLength);
+            uint hash = HashLower(prefixSpan);
+            if (binTree.Objects.TryGetValue(hash, out rootObject))
+            {
+                remainingIndex = currentLength;
+                if (remainingIndex < pathSpan.Length && (pathSpan[remainingIndex] == '/' || pathSpan[remainingIndex] == '\\'))
+                {
+                    remainingIndex++; // Skip the slash
+                }
+                break;
+            }
+
+            if (nextSep == -1)
+                break;
+            currentLength += 1; // Skip the separator for next loop
+        }
+
+        // If no prefix matched, check if the first segment is a raw hex/decimal hash representation
+        if (rootObject == null)
+        {
+            int firstSep = pathSpan.IndexOfAny('/', '\\');
+            ReadOnlySpan<char> firstSegment = firstSep == -1 ? pathSpan : pathSpan.Slice(0, firstSep);
+
+            if (firstSegment.StartsWith("0x", StringComparison.OrdinalIgnoreCase) &&
+                uint.TryParse(firstSegment.Slice(2), System.Globalization.NumberStyles.HexNumber, null, out uint hash))
+            {
+                if (binTree.Objects.TryGetValue(hash, out rootObject))
+                    remainingIndex = firstSep == -1 ? pathSpan.Length : firstSep + 1;
+            }
+            else if (uint.TryParse(firstSegment, out uint rawHash))
+            {
+                if (binTree.Objects.TryGetValue(rawHash, out rootObject))
+                    remainingIndex = firstSep == -1 ? pathSpan.Length : firstSep + 1;
+            }
+        }
+
+        if (rootObject == null)
+            return false;
+
+        // If the path refers exactly to the object and doesn't specify any property
+        if (remainingIndex >= pathSpan.Length)
+            return false;
+
+        // 2. Traverse down from the root object
+        return TryGetPropertyFromObject(rootObject, pathSpan.Slice(remainingIndex), out property);
+    }
+
+    /// <summary>
+    /// Resolves a property path starting from a specific <see cref="BinTreeObject"/>.
+    /// </summary>
+    /// <param name="obj">The object to start traversing from.</param>
+    /// <param name="path">The path to the property (e.g., "mResourceResolver/vfx").</param>
+    /// <returns>The resolved property, or <see langword="null"/> if not found.</returns>
+    public static BinTreeProperty GetProperty(this BinTreeObject obj, string path)
+    {
+        return obj.TryGetProperty(path, out var property) ? property : null;
+    }
+
+    /// <summary>
+    /// Tries to resolve a property path starting from a specific <see cref="BinTreeObject"/>.
+    /// </summary>
+    /// <param name="obj">The object to start traversing from.</param>
+    /// <param name="path">The path to the property.</param>
+    /// <param name="property">The resolved property if found; otherwise, <see langword="null"/>.</param>
+    /// <returns><see langword="true"/> if the property was successfully resolved; otherwise, <see langword="false"/>.</returns>
+    public static bool TryGetProperty(this BinTreeObject obj, string path, out BinTreeProperty property)
+    {
+        property = null;
+        if (string.IsNullOrEmpty(path))
+            return false;
+
+        return TryGetPropertyFromObject(obj, path.AsSpan(), out property);
+    }
+
+    private static bool TryGetPropertyFromObject(BinTreeObject obj, ReadOnlySpan<char> remainingPath, out BinTreeProperty property)
+    {
+        property = null;
+        if (remainingPath.IsEmpty)
+            return false;
+
+        int sepIndex = remainingPath.IndexOfAny('/', '\\');
+        ReadOnlySpan<char> segment = sepIndex == -1 ? remainingPath : remainingPath.Slice(0, sepIndex);
+        ReadOnlySpan<char> nextRemaining = sepIndex == -1 ? ReadOnlySpan<char>.Empty : remainingPath.Slice(sepIndex + 1);
+
+        ParseSegmentIndex(segment, out var propName, out int index);
+
+        uint propHash = HashLower(propName);
+        if (!obj.Properties.TryGetValue(propHash, out var currentProperty))
+        {
+            // Support raw hash fallback
+            if (propName.StartsWith("0x", StringComparison.OrdinalIgnoreCase) &&
+                uint.TryParse(propName.Slice(2), System.Globalization.NumberStyles.HexNumber, null, out uint rawHash))
+            {
+                if (!obj.Properties.TryGetValue(rawHash, out currentProperty))
+                    return false;
+            }
+            else if (uint.TryParse(propName, out uint rawHash2))
+            {
+                if (!obj.Properties.TryGetValue(rawHash2, out currentProperty))
+                    return false;
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        // Apply array index navigation if present
+        if (index != -1)
+        {
+            if (currentProperty is BinTreeContainer container)
+            {
+                if (index < 0 || index >= container.Elements.Count)
+                    return false;
+                currentProperty = container.Elements[index];
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        return TryGetPropertyFromProperty(currentProperty, nextRemaining, out property);
+    }
+
+    private static bool TryGetPropertyFromProperty(BinTreeProperty currentProperty, ReadOnlySpan<char> remainingPath, out BinTreeProperty property)
+    {
+        if (remainingPath.IsEmpty)
+        {
+            property = currentProperty;
+            return true;
+        }
+
+        property = null;
+        int sepIndex = remainingPath.IndexOfAny('/', '\\');
+        ReadOnlySpan<char> segment = sepIndex == -1 ? remainingPath : remainingPath.Slice(0, sepIndex);
+        ReadOnlySpan<char> nextRemaining = sepIndex == -1 ? ReadOnlySpan<char>.Empty : remainingPath.Slice(sepIndex + 1);
+
+        ParseSegmentIndex(segment, out var propName, out int index);
+
+        // 1. Struct or Embedded Property Traversal
+        if (currentProperty is BinTreeStruct structProperty)
+        {
+            uint propHash = HashLower(propName);
+            if (!structProperty.Properties.TryGetValue(propHash, out var nextProperty))
+            {
+                if (propName.StartsWith("0x", StringComparison.OrdinalIgnoreCase) &&
+                    uint.TryParse(propName.Slice(2), System.Globalization.NumberStyles.HexNumber, null, out uint rawHash))
+                {
+                    if (!structProperty.Properties.TryGetValue(rawHash, out nextProperty))
+                        return false;
+                }
+                else if (uint.TryParse(propName, out uint rawHash2))
+                {
+                    if (!structProperty.Properties.TryGetValue(rawHash2, out nextProperty))
+                        return false;
+                }
+                else
+                {
+                    return false;
+                }
+            }
+
+            if (index != -1)
+            {
+                if (nextProperty is BinTreeContainer container)
+                {
+                    if (index < 0 || index >= container.Elements.Count)
+                        return false;
+                    nextProperty = container.Elements[index];
+                }
+                else
+                {
+                    return false;
+                }
+            }
+
+            return TryGetPropertyFromProperty(nextProperty, nextRemaining, out property);
+        }
+
+        // 2. Optional Property Traversal
+        if (currentProperty is BinTreeOptional optionalProperty && optionalProperty.Value != null)
+        {
+            uint nextHash = HashLower(propName);
+            if (optionalProperty.Value.NameHash == nextHash)
+            {
+                var nextProperty = optionalProperty.Value;
+                if (index != -1)
+                {
+                    if (nextProperty is BinTreeContainer container)
+                    {
+                        if (index < 0 || index >= container.Elements.Count)
+                            return false;
+                        nextProperty = container.Elements[index];
+                    }
+                    else
+                    {
+                        return false;
+                    }
+                }
+                return TryGetPropertyFromProperty(nextProperty, nextRemaining, out property);
+            }
+            // Transparently skip the optional wrapper if the child is a Struct and contains the property directly
+            else if (optionalProperty.Value is BinTreeStruct optionalStruct)
+            {
+                if (optionalStruct.Properties.TryGetValue(nextHash, out var nextProperty))
+                {
+                    if (index != -1)
+                    {
+                        if (nextProperty is BinTreeContainer container)
+                        {
+                            if (index < 0 || index >= container.Elements.Count)
+                                return false;
+                            nextProperty = container.Elements[index];
+                        }
+                        else
+                        {
+                            return false;
+                        }
+                    }
+                    return TryGetPropertyFromProperty(nextProperty, nextRemaining, out property);
+                }
+            }
+        }
+
+        // 3. Map Property Traversal
+        if (currentProperty is BinTreeMap mapProperty)
+        {
+            BinTreeProperty matchedKey = null;
+            foreach (var key in mapProperty.Keys)
+            {
+                if (KeyMatches(key, propName))
+                {
+                    matchedKey = key;
+                    break;
+                }
+            }
+
+            if (matchedKey != null)
+            {
+                var nextProperty = mapProperty[matchedKey];
+                if (index != -1)
+                {
+                    if (nextProperty is BinTreeContainer container)
+                    {
+                        if (index < 0 || index >= container.Elements.Count)
+                            return false;
+                        nextProperty = container.Elements[index];
+                    }
+                    else
+                    {
+                        return false;
+                    }
+                }
+                return TryGetPropertyFromProperty(nextProperty, nextRemaining, out property);
+            }
+        }
+
+        return false;
+    }
+
+    private static void ParseSegmentIndex(ReadOnlySpan<char> segment, out ReadOnlySpan<char> name, out int index)
+    {
+        name = segment;
+        index = -1;
+        int bracketIndex = segment.IndexOf('[');
+        if (bracketIndex != -1 && segment.Length > 0 && segment[segment.Length - 1] == ']')
+        {
+            name = segment.Slice(0, bracketIndex);
+            if (int.TryParse(segment.Slice(bracketIndex + 1, segment.Length - bracketIndex - 2), out int parsedIndex))
+            {
+                index = parsedIndex;
+            }
+        }
+    }
+
+    private static bool KeyMatches(BinTreeProperty key, ReadOnlySpan<char> segment)
+    {
+        if (key is BinTreeString strKey && segment.Equals(strKey.Value.AsSpan(), StringComparison.Ordinal))
+            return true;
+
+        if (key is BinTreeHash hashKey)
+        {
+            if (hashKey.Value == HashLower(segment))
+                return true;
+            if (segment.StartsWith("0x", StringComparison.OrdinalIgnoreCase) &&
+                uint.TryParse(segment.Slice(2), System.Globalization.NumberStyles.HexNumber, null, out uint rawHash) &&
+                hashKey.Value == rawHash)
+                return true;
+            if (uint.TryParse(segment, out uint rawHash2))
+            {
+                if (hashKey.Value == rawHash2)
+                    return true;
+            }
+        }
+
+        if (key is BinTreeU32 u32Key && uint.TryParse(segment, out uint u32Val) && u32Key.Value == u32Val)
+            return true;
+
+        if (key is BinTreeI32 i32Key && int.TryParse(segment, out int i32Val) && i32Key.Value == i32Val)
+            return true;
+
+        return false;
+    }
+
+    private static uint HashLower(ReadOnlySpan<char> input)
+    {
+        uint hash = 2166136261;
+        for (int i = 0; i < input.Length; i++)
+        {
+            char c = input[i];
+            // Convert to lowercase invariant
+            if (c >= 'A' && c <= 'Z')
+                c = (char)(c + 32);
+            hash ^= c;
+            hash *= 16777619;
+        }
+        return hash;
+    }
+}


### PR DESCRIPTION
## Summary
This pull (#258) and linked to my other PR (#327) implements a pathing and navigation system for `BinTree` configurations. It allows querying nested properties using string-based paths (e.g., `characters/Aatrox/skins/skin0`), drastically simplifying how developers read deeply nested properties from League of Legends BIN files.

## Key Changes
- **Path Traversal System (`BinTreeExtensions.cs`)**:
- Supports traversing structures (`BinTreeStruct` and nested embedded properties) via string names or raw hashes.
- Transparently unwraps optional properties (`BinTreeOptional`).
- Implements map traversing (`BinTreeMap`) with dynamic key matching (matching strings, hashes, U32, and I32 keys).
- Supports container index access (`[index]`) for list collections (`BinTreeContainer`).
- Uses allocation-free path slicing using `ReadOnlySpan<char>`.
 - **Unit Testing Suite (`BinTreeExtensionsTests.cs`)**:
- Adds comprehensive unit tests validating path resolution logic, optional value skips, index boundaries, and key type matchings.