### PR TITLE
perf(core): optimize model and geometry loading efficiency

### DIFF
--- a/src/LeagueToolkit/Core/Animation/AnimationAsset.cs
+++ b/src/LeagueToolkit/Core/Animation/AnimationAsset.cs
@@ -1,5 +1,6 @@
 ﻿using System.Numerics;
 using System.Text;
+using LeagueToolkit.Utils.Extensions;
 
 namespace LeagueToolkit.Core.Animation;
 
@@ -44,7 +45,7 @@ public static class AnimationAsset
     {
         using BinaryReader br = new(stream, Encoding.UTF8, true);
 
-        string magic = Encoding.ASCII.GetString(br.ReadBytes(8));
+        string magic = br.ReadFixedString(8, Encoding.ASCII);
         br.BaseStream.Seek(0, SeekOrigin.Begin);
 
         return magic switch

--- a/src/LeagueToolkit/Core/Animation/CompressedAnimationAsset.cs
+++ b/src/LeagueToolkit/Core/Animation/CompressedAnimationAsset.cs
@@ -60,7 +60,7 @@ public sealed class CompressedAnimationAsset : IAnimationAsset
     {
         using BinaryReader br = new(stream, Encoding.UTF8, true);
 
-        string magic = Encoding.ASCII.GetString(br.ReadBytes(8));
+        string magic = br.ReadFixedString(8, Encoding.ASCII);
         uint version = br.ReadUInt32();
 
         if (magic is "r3d2anmd")

--- a/src/LeagueToolkit/Core/Animation/RigResource.cs
+++ b/src/LeagueToolkit/Core/Animation/RigResource.cs
@@ -59,8 +59,8 @@ public sealed class RigResource
         this.Flags = flags;
         this.Name = name;
         this.AssetName = assetName;
-        this._joints = joints.ToArray();
-        this._influences = influences.ToArray();
+        this._joints = joints as Joint[] ?? joints.ToArray();
+        this._influences = influences as short[] ?? influences.ToArray();
     }
 
     /// <summary>
@@ -167,7 +167,7 @@ public sealed class RigResource
 
     private void ReadLegacy(BinaryReader br)
     {
-        string magic = Encoding.ASCII.GetString(br.ReadBytes(8));
+        string magic = br.ReadFixedString(8, Encoding.ASCII);
         if (magic != "r3d2sklt")
             throw new InvalidFileSignatureException();
 
@@ -399,18 +399,23 @@ internal readonly struct RigResourceLegacyJoint
         string name = br.ReadPaddedString(32);
         short parentId = (short)br.ReadInt32();
         float radius = br.ReadSingle();
-        float[,] transform = new float[4, 4];
-        transform[0, 3] = 0;
-        transform[1, 3] = 0;
-        transform[2, 3] = 0;
-        transform[3, 3] = 1;
-        for (int i = 0; i < 3; i++)
-        {
-            for (int j = 0; j < 4; j++)
-            {
-                transform[j, i] = br.ReadSingle();
-            }
-        }
+
+        // Matrix is stored as 3 columns of 4 rows (column-major)
+        // Read directly into fields to avoid allocations
+        float m11 = br.ReadSingle();
+        float m21 = br.ReadSingle();
+        float m31 = br.ReadSingle();
+        float m41 = br.ReadSingle();
+
+        float m12 = br.ReadSingle();
+        float m22 = br.ReadSingle();
+        float m32 = br.ReadSingle();
+        float m42 = br.ReadSingle();
+
+        float m13 = br.ReadSingle();
+        float m23 = br.ReadSingle();
+        float m33 = br.ReadSingle();
+        float m43 = br.ReadSingle();
 
         return new()
         {
@@ -420,22 +425,10 @@ internal readonly struct RigResourceLegacyJoint
             Radius = radius,
             GlobalTransform = new Matrix4x4()
             {
-                M11 = transform[0, 0],
-                M12 = transform[0, 1],
-                M13 = transform[0, 2],
-                M14 = transform[0, 3],
-                M21 = transform[1, 0],
-                M22 = transform[1, 1],
-                M23 = transform[1, 2],
-                M24 = transform[1, 3],
-                M31 = transform[2, 0],
-                M32 = transform[2, 1],
-                M33 = transform[2, 2],
-                M34 = transform[2, 3],
-                M41 = transform[3, 0],
-                M42 = transform[3, 1],
-                M43 = transform[3, 2],
-                M44 = transform[3, 3],
+                M11 = m11, M12 = m12, M13 = m13, M14 = 0,
+                M21 = m21, M22 = m22, M23 = m23, M24 = 0,
+                M31 = m31, M32 = m32, M33 = m33, M34 = 0,
+                M41 = m41, M42 = m42, M43 = m43, M44 = 1,
             }
         };
     }

--- a/src/LeagueToolkit/Core/Animation/UncompressedAnimationAsset.cs
+++ b/src/LeagueToolkit/Core/Animation/UncompressedAnimationAsset.cs
@@ -30,7 +30,7 @@ public sealed class UncompressedAnimationAsset : IAnimationAsset
     {
         using BinaryReader br = new(stream, Encoding.UTF8, true);
 
-        string magic = Encoding.ASCII.GetString(br.ReadBytes(8));
+        string magic = br.ReadFixedString(8, Encoding.ASCII);
         uint version = br.ReadUInt32();
 
         if (magic is "r3d2canm")

--- a/src/LeagueToolkit/Core/Environment/Builder/EnvironmentAssetMeshBuilder.cs
+++ b/src/LeagueToolkit/Core/Environment/Builder/EnvironmentAssetMeshBuilder.cs
@@ -152,7 +152,7 @@ public sealed class EnvironmentAssetMeshBuilder
         Vector2 bias
     )
     {
-        this._textureOverrides = textureOverrides.ToArray();
+        this._textureOverrides = textureOverrides as EnvironmentAssetMeshTextureOverride[] ?? textureOverrides.ToArray();
         this._bakedPaintScale = scale;
         this._bakedPaintBias = bias;
         return this;

--- a/src/LeagueToolkit/Core/Environment/EnvironmentAsset.cs
+++ b/src/LeagueToolkit/Core/Environment/EnvironmentAsset.cs
@@ -55,8 +55,8 @@ public sealed class EnvironmentAsset : IDisposable
         this._sceneGraphs = new(sceneGraphs);
         this._planarReflectors = new(planarReflectors);
 
-        this._vertexBuffers = vertexBuffers.ToArray();
-        this._indexBuffers = indexBuffers.ToArray();
+        this._vertexBuffers = vertexBuffers as VertexBuffer[] ?? vertexBuffers.ToArray();
+        this._indexBuffers = indexBuffers as IndexBuffer[] ?? indexBuffers.ToArray();
     }
 
     /// <summary>
@@ -69,7 +69,7 @@ public sealed class EnvironmentAsset : IDisposable
     {
         using BinaryReader br = new(stream, Encoding.UTF8, true);
 
-        string magic = Encoding.ASCII.GetString(br.ReadBytes(4));
+        string magic = br.ReadFixedString(4, Encoding.ASCII);
         if (magic != "OEGM")
             throw new InvalidFileSignatureException();
 

--- a/src/LeagueToolkit/Core/Environment/EnvironmentAssetChannel.cs
+++ b/src/LeagueToolkit/Core/Environment/EnvironmentAssetChannel.cs
@@ -48,7 +48,7 @@ public struct EnvironmentAssetChannel
     {
         return new()
         {
-            Texture = Encoding.UTF8.GetString(br.ReadBytes(br.ReadInt32())),
+            Texture = br.ReadSizedString(Encoding.UTF8),
             Scale = br.ReadVector2(),
             Bias = br.ReadVector2()
         };

--- a/src/LeagueToolkit/Core/Environment/EnvironmentAssetMesh.cs
+++ b/src/LeagueToolkit/Core/Environment/EnvironmentAssetMesh.cs
@@ -165,7 +165,7 @@ public sealed class EnvironmentAssetMesh
         int version
     )
     {
-        this.Name = version <= 11 ? Encoding.ASCII.GetString(br.ReadBytes(br.ReadInt32())) : CreateName(id);
+        this.Name = version <= 11 ? br.ReadSizedString(Encoding.ASCII) : CreateName(id);
 
         int vertexCount = br.ReadInt32();
         uint vertexDeclarationCount = br.ReadUInt32();

--- a/src/LeagueToolkit/Core/Environment/EnvironmentAssetMeshPrimitive.cs
+++ b/src/LeagueToolkit/Core/Environment/EnvironmentAssetMeshPrimitive.cs
@@ -1,4 +1,5 @@
 ﻿using LeagueToolkit.Hashing;
+using LeagueToolkit.Utils.Extensions;
 using System.Text;
 
 namespace LeagueToolkit.Core.Environment;
@@ -56,7 +57,7 @@ public readonly struct EnvironmentAssetMeshPrimitive
     internal EnvironmentAssetMeshPrimitive(BinaryReader br)
     {
         this.Hash = br.ReadUInt32();
-        this.Material = Encoding.ASCII.GetString(br.ReadBytes(br.ReadInt32()));
+        this.Material = br.ReadSizedString(Encoding.ASCII);
         this.StartIndex = br.ReadInt32();
         this.IndexCount = br.ReadInt32();
         this.MinVertex = br.ReadInt32();

--- a/src/LeagueToolkit/Core/Environment/SimpleEnvironment.cs
+++ b/src/LeagueToolkit/Core/Environment/SimpleEnvironment.cs
@@ -15,7 +15,7 @@ public static class SimpleEnvironment
     {
         using BinaryReader br = new(stream, Encoding.UTF8, true);
 
-        string magic = Encoding.UTF8.GetString(br.ReadBytes(4));
+        string magic = br.ReadFixedString(4, Encoding.UTF8);
         if (magic is not "NVR\0")
             throw new InvalidFileSignatureException();
 

--- a/src/LeagueToolkit/Core/Environment/SimpleEnvironmentMaterial.cs
+++ b/src/LeagueToolkit/Core/Environment/SimpleEnvironmentMaterial.cs
@@ -25,7 +25,7 @@ internal readonly struct SimpleEnvironmentMaterial
         this.Name = name;
         this.Type = type;
         this.Flags = flags;
-        this.Channels = channels.ToArray();
+        this.Channels = channels as SimpleEnvironmentChannel[] ?? channels.ToArray();
     }
 
     public static SimpleEnvironmentMaterial Read(BinaryReader br)

--- a/src/LeagueToolkit/Core/Environment/WorldGeometry.cs
+++ b/src/LeagueToolkit/Core/Environment/WorldGeometry.cs
@@ -19,7 +19,7 @@ public static class WorldGeometry
     {
         using BinaryReader br = new(stream, Encoding.UTF8, true);
 
-        string magic = Encoding.ASCII.GetString(br.ReadBytes(4));
+        string magic = br.ReadFixedString(4, Encoding.ASCII);
         if (magic is not "WGEO")
             throw new InvalidFileSignatureException();
 

--- a/src/LeagueToolkit/Core/Legacy/IO/AiMesh/AiMeshFile.cs
+++ b/src/LeagueToolkit/Core/Legacy/IO/AiMesh/AiMeshFile.cs
@@ -1,4 +1,5 @@
 ﻿using LeagueToolkit.Utils.Exceptions;
+using LeagueToolkit.Utils.Extensions;
 using System.Text;
 
 namespace LeagueToolkit.IO.AiMesh;
@@ -11,7 +12,7 @@ public class AiMeshFile
     /// <summary>
     /// A collection of <see cref="AiMeshCell"/>
     /// </summary>
-    public List<AiMeshCell> Cells { get; private set; }
+    public List<AiMeshCell> Cells { get; private set; } = new();
 
     /// <summary>
     /// Initializes a new <see cref="AiMeshFile"/> with cells
@@ -35,7 +36,7 @@ public class AiMeshFile
     {
         using (BinaryReader br = new BinaryReader(stream))
         {
-            string magic = Encoding.ASCII.GetString(br.ReadBytes(8));
+            string magic = br.ReadFixedString(8, Encoding.ASCII);
             if (magic != "r3d2aims")
             {
                 throw new InvalidFileSignatureException();

--- a/src/LeagueToolkit/Core/Legacy/IO/MapObjects/MOBFile.cs
+++ b/src/LeagueToolkit/Core/Legacy/IO/MapObjects/MOBFile.cs
@@ -1,4 +1,5 @@
 ﻿using LeagueToolkit.Utils.Exceptions;
+using LeagueToolkit.Utils.Extensions;
 using System.Text;
 
 namespace LeagueToolkit.IO.MapObjects;
@@ -41,7 +42,7 @@ public class MOBFile
     {
         using BinaryReader br = new(stream);
 
-        string magic = Encoding.ASCII.GetString(br.ReadBytes(4));
+        string magic = br.ReadFixedString(4, Encoding.ASCII);
         if (magic != "OPAM")
         {
             throw new InvalidFileSignatureException();

--- a/src/LeagueToolkit/Core/Memory/VertexBufferDescription.cs
+++ b/src/LeagueToolkit/Core/Memory/VertexBufferDescription.cs
@@ -41,7 +41,7 @@ namespace LeagueToolkit.Core.Memory
         public VertexBufferDescription(VertexBufferUsage usage, IEnumerable<VertexElement> elements)
         {
             this.Usage = usage;
-            this._elements = elements.ToArray();
+            this._elements = elements as VertexElement[] ?? elements.ToArray();
             this.DescriptionFlags = GetElementFlags(this._elements.Select(elem => elem.Name));
         }
 
@@ -50,7 +50,7 @@ namespace LeagueToolkit.Core.Memory
             VertexBufferUsage usage = (VertexBufferUsage)br.ReadUInt32();
             uint vertexElementCount = br.ReadUInt32();
 
-            return new(usage, ReadElements().ToArray());
+            return new(usage, ReadElements());
 
             IEnumerable<VertexElement> ReadElements()
             {

--- a/src/LeagueToolkit/Core/Mesh/SkinnedMesh.cs
+++ b/src/LeagueToolkit/Core/Mesh/SkinnedMesh.cs
@@ -41,7 +41,7 @@ public sealed class SkinnedMesh : IDisposable
     /// <param name="indexBuffer">The index buffer of the <see cref="SkinnedMesh"/></param>
     public SkinnedMesh(IEnumerable<SkinnedMeshRange> ranges, VertexBuffer vertexBuffer, IndexBuffer indexBuffer)
     {
-        this._ranges = ranges.ToArray();
+        this._ranges = ranges as SkinnedMeshRange[] ?? ranges.ToArray();
         this._vertexBuffer = vertexBuffer;
         this._indexBuffer = indexBuffer;
 

--- a/src/LeagueToolkit/Core/Mesh/StaticMesh.cs
+++ b/src/LeagueToolkit/Core/Mesh/StaticMesh.cs
@@ -32,8 +32,8 @@ public class StaticMesh
 
         this.Name = name;
 
-        this._vertices = vertices.ToArray();
-        this._faces = faces.ToArray();
+        this._vertices = vertices as Vector3[] ?? vertices.ToArray();
+        this._faces = faces as StaticMeshFace[] ?? faces.ToArray();
 
         this.HasVertexColors = false;
     }
@@ -54,9 +54,9 @@ public class StaticMesh
 
         this.HasVertexColors = true;
 
-        this._vertices = vertices.ToArray();
-        this._vertexColors = vertexColors.ToArray();
-        this._faces = faces.ToArray();
+        this._vertices = vertices as Vector3[] ?? vertices.ToArray();
+        this._vertexColors = vertexColors as Color[] ?? vertexColors.ToArray();
+        this._faces = faces as StaticMeshFace[] ?? faces.ToArray();
 
         if (this._vertices.Length != this._vertexColors.Length)
             ThrowHelper.ThrowArgumentException("Vertex colors count must match vertices count");
@@ -66,7 +66,7 @@ public class StaticMesh
     {
         using BinaryReader br = new(stream);
 
-        string magic = Encoding.ASCII.GetString(br.ReadBytes(8));
+        string magic = br.ReadFixedString(8, Encoding.ASCII);
         if (magic is not "r3d2Mesh")
             throw new InvalidFileSignatureException();
 
@@ -98,9 +98,12 @@ public class StaticMesh
         if (hasVertexColors)
         {
             vertexColors = new Color[vertexCount];
+            int formatSize = Color.GetFormatSize(ColorFormat.BgraU8);
+            byte[] colorBuffer = new byte[vertexCount * formatSize];
+            br.BaseStream.ReadExact(colorBuffer);
 
             for (int i = 0; i < vertexCount; i++)
-                vertexColors[i] = br.ReadColor(ColorFormat.BgraU8);
+                vertexColors[i] = Color.Read(colorBuffer.AsSpan(i * formatSize, formatSize), ColorFormat.BgraU8);
         }
 
         Vector3 centralPoint = br.ReadVector3();
@@ -112,13 +115,22 @@ public class StaticMesh
 
         // Read face vertex colors ??
         if (flags.HasFlag(StaticMeshFlags.HasVcp))
+        {
+            int faceColorFormatSize = Color.GetFormatSize(ColorFormat.RgbU8);
+            byte[] faceColorBuffer = new byte[faceCount * 3 * faceColorFormatSize];
+            br.BaseStream.ReadExact(faceColorBuffer);
+
             for (int i = 0; i < faceCount; i++)
+            {
+                int baseIndex = i * 3 * faceColorFormatSize;
                 faces[i] = faces[i] with
                 {
-                    Color0 = br.ReadColor(ColorFormat.RgbU8),
-                    Color1 = br.ReadColor(ColorFormat.RgbU8),
-                    Color2 = br.ReadColor(ColorFormat.RgbU8)
+                    Color0 = Color.Read(faceColorBuffer.AsSpan(baseIndex, faceColorFormatSize), ColorFormat.RgbU8),
+                    Color1 = Color.Read(faceColorBuffer.AsSpan(baseIndex + faceColorFormatSize, faceColorFormatSize), ColorFormat.RgbU8),
+                    Color2 = Color.Read(faceColorBuffer.AsSpan(baseIndex + 2 * faceColorFormatSize, faceColorFormatSize), ColorFormat.RgbU8)
                 };
+            }
+        }
 
         return hasVertexColors switch
         {

--- a/src/LeagueToolkit/Core/Mesh/StaticMeshFace.cs
+++ b/src/LeagueToolkit/Core/Mesh/StaticMeshFace.cs
@@ -3,6 +3,8 @@ using LeagueToolkit.Core.Primitives;
 using LeagueToolkit.Utils.Extensions;
 using System.Globalization;
 using System.Numerics;
+using System.Runtime.InteropServices;
+using System.Text;
 
 namespace LeagueToolkit.Core.Mesh;
 
@@ -52,20 +54,17 @@ public readonly struct StaticMeshFace
 
     internal static StaticMeshFace ReadBinary(BinaryReader br)
     {
-        // indices are 16-bit internally
-        (ushort, ushort, ushort) indices = ((ushort)br.ReadUInt32(), (ushort)br.ReadUInt32(), (ushort)br.ReadUInt32());
+        Span<byte> buffer = stackalloc byte[12 + 64 + 24]; // 3*uint32 + 64 (material) + 6*float32
+        br.ReadExact(buffer);
 
-        string material = br.ReadPaddedString(64);
+        ReadOnlySpan<uint> indicesBuffer = MemoryMarshal.Cast<byte, uint>(buffer.Slice(0, 12));
+        (ushort, ushort, ushort) indices = ((ushort)indicesBuffer[0], (ushort)indicesBuffer[1], (ushort)indicesBuffer[2]);
 
-        ReadOnlySpan<float> uvs =
-            stackalloc float[] {
-                br.ReadSingle(),
-                br.ReadSingle(),
-                br.ReadSingle(),
-                br.ReadSingle(),
-                br.ReadSingle(),
-                br.ReadSingle()
-            };
+        ReadOnlySpan<byte> materialBuffer = buffer.Slice(12, 64);
+        int nullIndex = materialBuffer.IndexOf((byte)0);
+        string material = Encoding.UTF8.GetString(nullIndex == -1 ? materialBuffer : materialBuffer.Slice(0, nullIndex));
+
+        ReadOnlySpan<float> uvs = MemoryMarshal.Cast<byte, float>(buffer.Slice(12 + 64));
 
         return new(material, indices, (new(uvs[0], uvs[3]), new(uvs[1], uvs[4]), new(uvs[2], uvs[5])));
     }

--- a/src/LeagueToolkit/Core/Meta/BinTree.cs
+++ b/src/LeagueToolkit/Core/Meta/BinTree.cs
@@ -1,6 +1,7 @@
 ﻿using CommunityToolkit.Diagnostics;
 using CommunityToolkit.HighPerformance;
 using LeagueToolkit.Utils.Exceptions;
+using LeagueToolkit.Utils.Extensions;
 using System.Text;
 
 namespace LeagueToolkit.Core.Meta;
@@ -61,7 +62,7 @@ public sealed class BinTree
     {
         using BinaryReader br = new(stream, Encoding.UTF8, true);
 
-        string magic = Encoding.ASCII.GetString(br.ReadBytes(4));
+        string magic = br.ReadFixedString(4, Encoding.ASCII);
         if (magic != "PROP" && magic != "PTCH")
             throw new InvalidFileSignatureException();
 
@@ -77,7 +78,7 @@ public sealed class BinTree
             // and set the original file as a dependency
             uint maybeOverrideObjectCount = br.ReadUInt32(); // this seems to be object count of override section
 
-            magic = Encoding.ASCII.GetString(br.ReadBytes(4));
+            magic = br.ReadFixedString(4, Encoding.ASCII);
             if (magic is not "PROP")
                 throw new InvalidFileSignatureException("Expected PROP section after PTCH, got: " + magic);
         }
@@ -91,7 +92,10 @@ public sealed class BinTree
         {
             uint dependencyCount = br.ReadUInt32();
             for (int i = 0; i < dependencyCount; i++)
-                this.Dependencies.Add(Encoding.ASCII.GetString(br.ReadBytes(br.ReadInt16())));
+            {
+                int length = br.ReadInt16();
+                this.Dependencies.Add(br.ReadFixedString(length, Encoding.ASCII));
+            }
         }
 
         // Read object classes

--- a/src/LeagueToolkit/Utils/Extensions/BinaryReaderExtensions.cs
+++ b/src/LeagueToolkit/Utils/Extensions/BinaryReaderExtensions.cs
@@ -59,27 +59,46 @@ internal static class BinaryReaderColorExtensions
         return new(position, radius);
     }
 
-    public static string ReadSizedString(this BinaryReader reader) =>
-        Encoding.UTF8.GetString(reader.ReadBytes(reader.ReadInt32()));
+    public static string ReadSizedString(this BinaryReader reader) => ReadSizedString(reader, Encoding.UTF8);
 
-    public static string ReadPaddedString(this BinaryReader reader, int length) =>
-        Encoding.UTF8.GetString(reader.ReadBytes(length).TakeWhile(b => !b.Equals(0)).ToArray());
+    public static string ReadSizedString(this BinaryReader reader, Encoding encoding)
+    {
+        int length = reader.ReadInt32();
+        if (length <= 0) return string.Empty;
+
+        Span<byte> buffer = length <= 1024 ? stackalloc byte[length] : new byte[length];
+        reader.BaseStream.ReadExact(buffer);
+        return encoding.GetString(buffer);
+    }
+
+    public static string ReadFixedString(this BinaryReader reader, int length, Encoding encoding)
+    {
+        if (length <= 0) return string.Empty;
+
+        Span<byte> buffer = length <= 1024 ? stackalloc byte[length] : new byte[length];
+        reader.BaseStream.ReadExact(buffer);
+        return encoding.GetString(buffer);
+    }
+
+    public static string ReadPaddedString(this BinaryReader reader, int length)
+    {
+        if (length <= 0) return string.Empty;
+
+        Span<byte> buffer = length <= 1024 ? stackalloc byte[length] : new byte[length];
+        reader.BaseStream.ReadExact(buffer);
+        int nullIndex = buffer.IndexOf((byte)0);
+        return Encoding.UTF8.GetString(nullIndex == -1 ? buffer : buffer.Slice(0, nullIndex));
+    }
 
     public static string ReadNullTerminatedString(this BinaryReader reader)
     {
-        string returnString = "";
-
+        var builder = new StringBuilder();
         while (true)
         {
-            char c = reader.ReadChar();
-            if (c == 0)
-            {
-                break;
-            }
-
-            returnString += c;
+            byte b = reader.ReadByte();
+            if (b == 0) break;
+            builder.Append((char)b);
         }
-
-        return returnString;
+        return builder.ToString();
     }
 }


### PR DESCRIPTION
## Summary
This pull request introduces a series of low-level performance optimizations to the core model, geometry, and
  animation parsing pipelines. The primary focus is reducing Garbage Collection (GC) pressure by avoiding heap
  allocations during file reading and minimizing `Stream`/`BinaryReader` call overhead through buffered batch reads
  and stackalloc-based string decoding.

## Key Changes

### 1. Zero-Allocation String Parsing (`BinaryReaderExtensions.cs`)
* **Heap Allocation Avoidance**: Rewrote string parsing methods (`ReadSizedString`, `ReadFixedString`, `ReadPaddedString`) to use `Span<byte>` and `stackalloc` for buffers <= 1024 bytes. This eliminates allocating temporary intermediate byte arrays on the heap for path names and identifiers.
* **Direct Span Searching**: `ReadPaddedString` now searches for the null-terminator using `Span. IndexOf((byte)0)` instead of allocating iterators through `.TakeWhile().ToArray()`.
* **Direct Stream Copying**: Replaced multiple small byte reads with a single direct `BaseStream. ReadExact(buffer)` call.

### 2. Zero-Allocation Struct Marshalling (`StaticMeshFace.cs`)
* **Single-Batch Read**: Replaced individual `BinaryReader.Read` calls for indices, material name padding (64 bytes), and UV coordinates with a single stream read of 100 bytes into a stack-allocated buffer.
* **Direct Memory Casts**: Utilized `MemoryMarshal.Cast<byte, T>` to read index and UV values directly from the stack-allocated span without any copying or heap allocations.

### 3. Single-Batch Vertex Color Reading (`StaticMesh.cs`)
* **Buffered Colors**: Instead of reading vertex colors one-by-one (`br.ReadColor()`) which triggers thousands of tiny stream requests, the code now reads the entire color buffer in a single batch read (`br.BaseStream. ReadExact()`) and parses individual vertex/face colors directly from the span.

### 4. Matrix Allocation Avoidance (`RigResource.cs`)
* **Stack-Allocated Matrix Parsing**: Replaced the allocation of a multi-dimensional heap array (`new float[4, 4]`) per legacy joint with local float variables. Values are read directly into stack fields to populate `Matrix4x4` structs, eliminating massive heap allocations during skeleton loading.

### 5. Array Copying Bypass (Multiple Files)
* **Cast Checks**: Added fast-path casting checks (`as T[] ?? ToArray()`) across `RigResource.cs`, `StaticMesh.cs`, and `VertexBufferDescription.cs` to prevent duplicating arrays that are already fully materialized in memory.