### PR TITLE
feat(mapgeometry): rename unknown_version18_int to regionHash

### DIFF
--- a/src/LeagueToolkit/Core/Environment/EnvironmentAssetMesh.cs
+++ b/src/LeagueToolkit/Core/Environment/EnvironmentAssetMesh.cs
@@ -1,4 +1,4 @@
-﻿using System.Numerics;
+using System.Numerics;
 using System.Text;
 using LeagueToolkit.Core.Memory;
 using LeagueToolkit.Core.Primitives;
@@ -36,9 +36,9 @@ public sealed class EnvironmentAssetMesh
     private readonly List<EnvironmentAssetMeshPrimitive> _submeshes = [];
 
     /// <summary>
-    /// Unknown Version 18 Int
+    /// Gets or sets the region hash linking the mesh to a special rendering zone
     /// </summary>
-    public uint UnknownVersion18Int { get; set; }
+    public uint RegionHash { get; set; }
 
     /// <summary>
     /// Gets the path hash of the scene graph that this mesh belongs to
@@ -199,7 +199,7 @@ public sealed class EnvironmentAssetMesh
 
         if (version >= 18)
         {
-            this.UnknownVersion18Int = br.ReadUInt32();
+            this.RegionHash = br.ReadUInt32();
         }
 
         if (version >= 15)


### PR DESCRIPTION
## Summary
Resolves #319.

This pull request renames the previously unidentified version 18 field `UnknownVersion18Int` (represented as unknown_version18_int` in file specifications) to `RegionHash` / `regionHash`. This field has been identified as a reference pointing to rendering region definitions (such as Faelights zones) inside the materials configuration file, which connects the 3D map meshes with their interactive region boundaries.

## Key Changes
*   **Property Renaming**: Changed `UnknownVersion18Int` to `RegionHash` in `EnvironmentAssetMesh.cs`.
*   **Parser Update**: Updated the binary reader assignment within the version 18 mesh deserialization flow to populate `RegionHash` directly.