### PR TITLE
feat(wad): support external chunk decompression

### DIFF
--- a/src/LeagueToolkit.Tests/Core/Wad/WadChunkDecompressorTests.cs
+++ b/src/LeagueToolkit.Tests/Core/Wad/WadChunkDecompressorTests.cs
@@ -1,0 +1,194 @@
+using LeagueToolkit.Core.Wad;
+using System.IO.Compression;
+using System.Text;
+using Xunit;
+
+namespace LeagueToolkit.Tests.Core.Wad;
+
+public class WadChunkDecompressorTests
+{
+    [Fact]
+    public void DecompressCopiesUncompressedPayload()
+    {
+        byte[] expected = "uncompressed payload"u8.ToArray();
+        using var decompressor = new WadChunkDecompressor();
+
+        using var actual = decompressor.Decompress(expected, WadChunkCompression.None, expected.Length);
+
+        Assert.Equal(expected, actual.Span.ToArray());
+    }
+
+    [Fact]
+    public void DecompressRejectsInvalidUncompressedSize()
+    {
+        byte[] payload = "payload"u8.ToArray();
+        using var decompressor = new WadChunkDecompressor();
+
+        Assert.Throws<InvalidDataException>(
+            () => decompressor.Decompress(payload, WadChunkCompression.None, payload.Length + 1)
+        );
+    }
+
+    [Fact]
+    public void DecompressSupportsGZipPayload()
+    {
+        byte[] expected = Encoding.UTF8.GetBytes(string.Concat(Enumerable.Repeat("gzip payload ", 32)));
+        byte[] compressed = CompressGZip(expected);
+        using var decompressor = new WadChunkDecompressor();
+
+        using var actual = decompressor.Decompress(compressed, WadChunkCompression.GZip, expected.Length);
+
+        Assert.Equal(expected, actual.Span.ToArray());
+    }
+
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(1)]
+    public void DecompressRejectsIncorrectGZipOutputSize(int sizeDelta)
+    {
+        byte[] expected = "gzip payload"u8.ToArray();
+        byte[] compressed = CompressGZip(expected);
+        using var decompressor = new WadChunkDecompressor();
+
+        Assert.Throws<InvalidDataException>(
+            () => decompressor.Decompress(compressed, WadChunkCompression.GZip, expected.Length + sizeDelta)
+        );
+    }
+
+    [Fact]
+    public void DecompressSupportsZstdPayload()
+    {
+        byte[] expected = Encoding.UTF8.GetBytes(string.Concat(Enumerable.Repeat("zstd payload ", 32)));
+        using var compressor = new ZstdSharp.Compressor();
+        byte[] compressed = compressor.Wrap(expected).ToArray();
+        using var decompressor = new WadChunkDecompressor();
+
+        using var actual = decompressor.Decompress(compressed, WadChunkCompression.Zstd, expected.Length);
+
+        Assert.Equal(expected, actual.Span.ToArray());
+    }
+
+    [Fact]
+    public void DecompressSupportsMixedZstdChunkedPayload()
+    {
+        byte[] compressedOutput = Encoding.UTF8.GetBytes(string.Concat(Enumerable.Repeat("compressed subchunk ", 32)));
+        byte[] rawOutput = "raw-subchunk-data"u8.ToArray();
+        using var compressor = new ZstdSharp.Compressor();
+        byte[] compressedInput = compressor.Wrap(compressedOutput).ToArray();
+        byte[] payload = [.. compressedInput, .. rawOutput];
+        WadSubchunk[] subchunks =
+        [
+            new(compressedInput.Length, compressedOutput.Length),
+            new(rawOutput.Length, rawOutput.Length)
+        ];
+        byte[] expected = [.. compressedOutput, .. rawOutput];
+        using var decompressor = new WadChunkDecompressor();
+
+        using var actual = decompressor.Decompress(
+            payload,
+            WadChunkCompression.ZstdChunked,
+            expected.Length,
+            subchunks
+        );
+
+        Assert.Equal(expected, actual.Span.ToArray());
+    }
+
+    [Fact]
+    public void DecompressRejectsMissingZstdSubchunkTable()
+    {
+        using var decompressor = new WadChunkDecompressor();
+
+        Assert.Throws<InvalidDataException>(
+            () => decompressor.Decompress(new byte[] { 1, 2, 3 }, WadChunkCompression.ZstdChunked, 3)
+        );
+    }
+
+    [Theory]
+    [InlineData(0, 1)]
+    [InlineData(1, 0)]
+    [InlineData(-1, 1)]
+    [InlineData(1, -1)]
+    public void DecompressRejectsInvalidZstdSubchunkSizes(int compressedSize, int uncompressedSize)
+    {
+        WadSubchunk[] subchunks = [new(compressedSize, uncompressedSize)];
+        using var decompressor = new WadChunkDecompressor();
+
+        Assert.Throws<InvalidDataException>(
+            () => decompressor.Decompress(
+                new byte[] { 1 },
+                WadChunkCompression.ZstdChunked,
+                1,
+                subchunks
+            )
+        );
+    }
+
+    [Theory]
+    [InlineData(2, 4)]
+    [InlineData(4, 2)]
+    public void DecompressRejectsMismatchedZstdSubchunkTable(int compressedSize, int uncompressedSize)
+    {
+        byte[] payload = [1, 2, 3];
+        WadSubchunk[] subchunks = [new(compressedSize, uncompressedSize)];
+        using var decompressor = new WadChunkDecompressor();
+
+        Assert.Throws<InvalidDataException>(
+            () => decompressor.Decompress(
+                payload,
+                WadChunkCompression.ZstdChunked,
+                payload.Length,
+                subchunks
+            )
+        );
+    }
+
+    [Fact]
+    public void DecompressDoesNotTreatCorruptCompressedSubchunkAsRaw()
+    {
+        byte[] payload = [1, 2, 3, 4];
+        WadSubchunk[] subchunks = [new(payload.Length, payload.Length + 1)];
+        using var decompressor = new WadChunkDecompressor();
+
+        Assert.Throws<ZstdSharp.ZstdException>(
+            () => decompressor.Decompress(
+                payload,
+                WadChunkCompression.ZstdChunked,
+                payload.Length + 1,
+                subchunks
+            )
+        );
+    }
+
+    [Fact]
+    public void DecompressRejectsUseAfterDispose()
+    {
+        var decompressor = new WadChunkDecompressor();
+        decompressor.Dispose();
+
+        Assert.Throws<ObjectDisposedException>(
+            () => decompressor.Decompress(ReadOnlyMemory<byte>.Empty, WadChunkCompression.None, 0)
+        );
+    }
+
+    [Fact]
+    public void DecompressRejectsSatellitePayload()
+    {
+        using var decompressor = new WadChunkDecompressor();
+
+        Assert.Throws<NotSupportedException>(
+            () => decompressor.Decompress(ReadOnlyMemory<byte>.Empty, WadChunkCompression.Satellite, 0)
+        );
+    }
+
+    private static byte[] CompressGZip(byte[] data)
+    {
+        using var output = new MemoryStream();
+        using (var compressionStream = new GZipStream(output, CompressionMode.Compress, true))
+        {
+            compressionStream.Write(data);
+        }
+
+        return output.ToArray();
+    }
+}

--- a/src/LeagueToolkit.Tests/Core/Wad/WadTests.cs
+++ b/src/LeagueToolkit.Tests/Core/Wad/WadTests.cs
@@ -44,6 +44,9 @@ public class WadTests
             file1Stream.CopyTo(ms1);
             Assert.Equal("Hello WAD file 1!", Encoding.UTF8.GetString(ms1.ToArray()));
 
+            using var file1Data = wad.LoadChunkDecompressed(file1Chunk);
+            Assert.Equal(file1Content, file1Data.Span.ToArray());
+
             // Verify second file
             var file2Chunk = wad.FindChunk("assets/text/file2.txt");
             using var file2Stream = wad.OpenChunk(file2Chunk);

--- a/src/LeagueToolkit/Core/Wad/WadChunkDecompressor.cs
+++ b/src/LeagueToolkit/Core/Wad/WadChunkDecompressor.cs
@@ -1,0 +1,210 @@
+using CommunityToolkit.Diagnostics;
+using CommunityToolkit.HighPerformance.Buffers;
+using System.IO.Compression;
+using System.Runtime.InteropServices;
+
+namespace LeagueToolkit.Core.Wad;
+
+/// <summary>
+/// Decompresses WAD chunk payloads independently from a <see cref="WadFile"/>
+/// </summary>
+/// <remarks>
+/// Instances are reusable but are not thread-safe.
+/// </remarks>
+public sealed class WadChunkDecompressor : IDisposable
+{
+    private readonly ZstdSharp.Decompressor _zstdDecompressor = new();
+
+    /// <summary>
+    /// Gets a value indicating whether the decompressor has been disposed of
+    /// </summary>
+    public bool IsDisposed { get; private set; }
+
+    /// <summary>
+    /// Decompresses an externally stored WAD chunk payload
+    /// </summary>
+    /// <param name="chunkData">The stored chunk payload</param>
+    /// <param name="compression">The compression used by the chunk</param>
+    /// <param name="uncompressedSize">The expected decompressed size</param>
+    /// <param name="subchunks">The sub-chunk table required by <see cref="WadChunkCompression.ZstdChunked"/></param>
+    /// <returns>An owner containing the decompressed chunk data</returns>
+    /// <exception cref="InvalidDataException">The payload or its metadata is inconsistent</exception>
+    /// <exception cref="NotSupportedException">The compression type cannot be decompressed</exception>
+    /// <exception cref="ObjectDisposedException">The decompressor has been disposed of</exception>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="uncompressedSize"/> is negative</exception>
+    /// <exception cref="ZstdSharp.ZstdException">A Zstandard payload cannot be decompressed</exception>
+    public MemoryOwner<byte> Decompress(
+        ReadOnlyMemory<byte> chunkData,
+        WadChunkCompression compression,
+        int uncompressedSize,
+        ReadOnlyMemory<WadSubchunk> subchunks = default
+    )
+    {
+        ThrowIfDisposed();
+        ArgumentOutOfRangeException.ThrowIfNegative(uncompressedSize);
+
+        ValidateMetadata(chunkData.Length, compression, uncompressedSize, subchunks.Span);
+
+        MemoryOwner<byte> decompressedData = MemoryOwner<byte>.Allocate(uncompressedSize);
+        try
+        {
+            switch (compression)
+            {
+                case WadChunkCompression.None:
+                    chunkData.Span.CopyTo(decompressedData.Span);
+                    break;
+                case WadChunkCompression.GZip:
+                    DecompressGZip(chunkData, decompressedData.Span);
+                    break;
+                case WadChunkCompression.Zstd:
+                    DecompressZstd(chunkData.Span, decompressedData.Span);
+                    break;
+                case WadChunkCompression.ZstdChunked:
+                    DecompressZstdChunked(chunkData.Span, decompressedData.Span, subchunks.Span);
+                    break;
+                case WadChunkCompression.Satellite:
+                    throw new NotSupportedException("Satellite chunks cannot be decompressed");
+                default:
+                    throw new InvalidDataException($"Invalid WAD chunk compression type: {compression}");
+            }
+
+            return decompressedData;
+        }
+        catch
+        {
+            decompressedData.Dispose();
+            throw;
+        }
+    }
+
+    private static void ValidateMetadata(
+        int compressedSize,
+        WadChunkCompression compression,
+        int uncompressedSize,
+        ReadOnlySpan<WadSubchunk> subchunks
+    )
+    {
+        if (!Enum.IsDefined(compression))
+            ThrowHelper.ThrowInvalidDataException($"Invalid WAD chunk compression type: {compression}");
+
+        if (compression is WadChunkCompression.Satellite)
+            throw new NotSupportedException("Satellite chunks cannot be decompressed");
+
+        if (compression is WadChunkCompression.None && compressedSize != uncompressedSize)
+            ThrowHelper.ThrowInvalidDataException(
+                $"Uncompressed chunk size mismatch. Expected {uncompressedSize}, got {compressedSize}"
+            );
+
+        if (compression is not WadChunkCompression.ZstdChunked)
+            return;
+
+        if (subchunks.IsEmpty)
+            ThrowHelper.ThrowInvalidDataException("Zstd chunked data requires a sub-chunk table");
+
+        int totalCompressedSize = 0;
+        int totalUncompressedSize = 0;
+        try
+        {
+            foreach (WadSubchunk subchunk in subchunks)
+            {
+                if (subchunk.CompressedSize <= 0 || subchunk.UncompressedSize <= 0)
+                    ThrowHelper.ThrowInvalidDataException("The sub-chunk table contains an invalid size");
+
+                totalCompressedSize = checked(totalCompressedSize + subchunk.CompressedSize);
+                totalUncompressedSize = checked(totalUncompressedSize + subchunk.UncompressedSize);
+            }
+        }
+        catch (OverflowException exception)
+        {
+            throw new InvalidDataException("The sub-chunk table exceeds the supported size", exception);
+        }
+
+        if (totalCompressedSize != compressedSize || totalUncompressedSize != uncompressedSize)
+            ThrowHelper.ThrowInvalidDataException(
+                $"Sub-chunk table size mismatch. Compressed {totalCompressedSize}/{compressedSize}, uncompressed {totalUncompressedSize}/{uncompressedSize}"
+            );
+    }
+
+    private static void DecompressGZip(ReadOnlyMemory<byte> source, Span<byte> destination)
+    {
+        Stream sourceStream = MemoryMarshal.TryGetArray(source, out ArraySegment<byte> segment)
+            ? new MemoryStream(segment.Array!, segment.Offset, segment.Count, false)
+            : new MemoryStream(source.ToArray(), false);
+
+        using (sourceStream)
+        using (var decompressionStream = new GZipStream(sourceStream, CompressionMode.Decompress))
+        {
+            int totalRead = 0;
+            while (totalRead < destination.Length)
+            {
+                int read = decompressionStream.Read(destination[totalRead..]);
+                if (read == 0)
+                    ThrowHelper.ThrowInvalidDataException("GZip chunk output is smaller than its declared size");
+
+                totalRead += read;
+            }
+
+            if (decompressionStream.ReadByte() != -1)
+                ThrowHelper.ThrowInvalidDataException("GZip chunk output exceeds its declared size");
+        }
+    }
+
+    private void DecompressZstd(ReadOnlySpan<byte> source, Span<byte> destination)
+    {
+        int written = this._zstdDecompressor.Unwrap(source, destination);
+        if (written != destination.Length)
+            ThrowHelper.ThrowInvalidDataException(
+                $"Zstd chunk size mismatch. Expected {destination.Length}, got {written}"
+            );
+    }
+
+    private void DecompressZstdChunked(
+        ReadOnlySpan<byte> source,
+        Span<byte> destination,
+        ReadOnlySpan<WadSubchunk> subchunks
+    )
+    {
+        int compressedOffset = 0;
+        int decompressedOffset = 0;
+
+        foreach (WadSubchunk subchunk in subchunks)
+        {
+            ReadOnlySpan<byte> subchunkSource = source.Slice(compressedOffset, subchunk.CompressedSize);
+            Span<byte> subchunkDestination = destination.Slice(decompressedOffset, subchunk.UncompressedSize);
+
+            try
+            {
+                DecompressZstd(subchunkSource, subchunkDestination);
+            }
+            catch (ZstdSharp.ZstdException) when (subchunk.CompressedSize == subchunk.UncompressedSize)
+            {
+                subchunkSource.CopyTo(subchunkDestination);
+            }
+
+            compressedOffset += subchunk.CompressedSize;
+            decompressedOffset += subchunk.UncompressedSize;
+        }
+    }
+
+    /// <summary>
+    /// Disposes the decompressor
+    /// </summary>
+    public void Dispose()
+    {
+        if (this.IsDisposed)
+            return;
+
+        this._zstdDecompressor.Dispose();
+        this.IsDisposed = true;
+        GC.SuppressFinalize(this);
+    }
+
+    private void ThrowIfDisposed()
+    {
+        if (this.IsDisposed)
+            ThrowHelper.ThrowObjectDisposedException(
+                nameof(WadChunkDecompressor),
+                "Cannot use a disposed WAD chunk decompressor"
+            );
+    }
+}

--- a/src/LeagueToolkit/Core/Wad/WadFile.cs
+++ b/src/LeagueToolkit/Core/Wad/WadFile.cs
@@ -2,7 +2,6 @@
 using CommunityToolkit.HighPerformance;
 using CommunityToolkit.HighPerformance.Buffers;
 using LeagueToolkit.Hashing;
-using LeagueToolkit.Utils.Extensions;
 using System;
 using System.Globalization;
 using System.IO.Compression;
@@ -27,11 +26,13 @@ public sealed class WadFile : IDisposable
     public IReadOnlyDictionary<ulong, WadChunk> Chunks => this._chunks;
     private readonly Dictionary<ulong, WadChunk> _chunks;
 
-    public ReadOnlyMemory<WadSubchunk> Subchunks => this._subchunkTocMemory.Memory.Cast<byte, WadSubchunk>();
+    public ReadOnlyMemory<WadSubchunk> Subchunks => this._subchunkTocMemory is null
+        ? ReadOnlyMemory<WadSubchunk>.Empty
+        : this._subchunkTocMemory.Memory.Cast<byte, WadSubchunk>();
     private readonly MemoryOwner<byte> _subchunkTocMemory;
 
     private readonly FileStream _stream;
-    private readonly ZstdSharp.Decompressor _zstdDecompressor = new();
+    private readonly WadChunkDecompressor _chunkDecompressor = new();
 
     /// <summary>
     /// Gets a value indicating whether the archive has been disposed of
@@ -189,12 +190,13 @@ public sealed class WadFile : IDisposable
     /// <returns>A <see cref="MemoryOwner{T}"/> object with the loaded decompresed chunk data</returns>
     public MemoryOwner<byte> LoadChunkDecompressed(WadChunk chunk)
     {
-        using Stream decompressionStream = OpenChunk(chunk);
-        MemoryOwner<byte> decompressedChunk = MemoryOwner<byte>.Allocate(chunk.UncompressedSize);
-
-        decompressionStream.ReadExact(decompressedChunk.Span);
-
-        return decompressedChunk;
+        using MemoryOwner<byte> chunkData = LoadChunk(chunk);
+        return this._chunkDecompressor.Decompress(
+            chunkData.Memory,
+            chunk.Compression,
+            chunk.UncompressedSize,
+            GetSubchunks(chunk)
+        );
     }
 
     /// <summary>
@@ -220,17 +222,33 @@ public sealed class WadFile : IDisposable
     {
         MemoryOwner<byte> chunkData = LoadChunk(chunk);
 
-        return chunk.Compression switch
+        if (chunk.Compression is WadChunkCompression.ZstdChunked)
         {
-            WadChunkCompression.None => chunkData.AsStream(),
-            WadChunkCompression.GZip => new GZipStream(chunkData.AsStream(), CompressionMode.Decompress),
-            WadChunkCompression.Satellite
-                => throw new NotImplementedException("Opening satellite chunks is not supported"),
-            WadChunkCompression.Zstd => new ZstdSharp.DecompressionStream(chunkData.AsStream()),
-            WadChunkCompression.ZstdChunked => DecompressZstdChunkedChunk(chunk, chunkData).AsStream(),
+            using (chunkData)
+            {
+                return this._chunkDecompressor
+                    .Decompress(chunkData.Memory, chunk.Compression, chunk.UncompressedSize, GetSubchunks(chunk))
+                    .AsStream();
+            }
+        }
 
-            _ => throw new InvalidOperationException($"Invalid chunk compression type: {chunk.Compression}")
-        };
+        try
+        {
+            return chunk.Compression switch
+            {
+                WadChunkCompression.None => chunkData.AsStream(),
+                WadChunkCompression.GZip => new GZipStream(chunkData.AsStream(), CompressionMode.Decompress),
+                WadChunkCompression.Satellite
+                    => throw new NotImplementedException("Opening satellite chunks is not supported"),
+                WadChunkCompression.Zstd => new ZstdSharp.DecompressionStream(chunkData.AsStream()),
+                _ => throw new InvalidOperationException($"Invalid chunk compression type: {chunk.Compression}")
+            };
+        }
+        catch
+        {
+            chunkData.Dispose();
+            throw;
+        }
     }
 
     /// <summary>
@@ -258,39 +276,17 @@ public sealed class WadFile : IDisposable
         return chunk;
     }
 
-    private MemoryOwner<byte> DecompressZstdChunkedChunk(WadChunk chunk, MemoryOwner<byte> chunkData)
+    private ReadOnlyMemory<WadSubchunk> GetSubchunks(WadChunk chunk)
     {
-        var decompressedData = MemoryOwner<byte>.Allocate(chunk.UncompressedSize);
-        ReadOnlySpan<WadSubchunk> subchunks = this.Subchunks.Span.Slice(chunk.StartSubChunk, chunk.SubChunkCount);
+        if (chunk.Compression is not WadChunkCompression.ZstdChunked)
+            return ReadOnlyMemory<WadSubchunk>.Empty;
 
-        int rawOffset = 0;
-        int decompressedOffset = 0;
-        for (int i = 0; i < subchunks.Length; i++)
-        {
-            WadSubchunk subchunk = subchunks[i];
+        if (chunk.StartSubChunk < 0
+            || chunk.SubChunkCount <= 0
+            || chunk.StartSubChunk > this.Subchunks.Length - chunk.SubChunkCount)
+            ThrowHelper.ThrowInvalidDataException("The WAD chunk references an invalid sub-chunk table range");
 
-            // Try decompressing subchunk
-            try
-            {
-                this._zstdDecompressor.Unwrap(
-                    chunkData.Span.Slice(rawOffset, subchunk.CompressedSize),
-                    decompressedData.Span[decompressedOffset..]
-                );
-            }
-            catch (ZstdSharp.ZstdException)
-            {
-                // If decompression failed, copy raw data to output buffer
-                chunkData.Span.CopyTo(decompressedData.Span[decompressedOffset..]);
-            }
-
-            rawOffset += subchunk.CompressedSize;
-            decompressedOffset += subchunk.UncompressedSize;
-        }
-
-        // Dispose of raw chunk data
-        chunkData.Dispose();
-
-        return decompressedData;
+        return this.Subchunks.Slice(chunk.StartSubChunk, chunk.SubChunkCount);
     }
 
     /// <summary>
@@ -311,6 +307,7 @@ public sealed class WadFile : IDisposable
         {
             this._stream?.Dispose();
             this._subchunkTocMemory?.Dispose();
+            this._chunkDecompressor.Dispose();
         }
 
         this.IsDisposed = true;

--- a/src/LeagueToolkit/Core/Wad/WadSubchunk.cs
+++ b/src/LeagueToolkit/Core/Wad/WadSubchunk.cs
@@ -1,8 +1,35 @@
 ﻿namespace LeagueToolkit.Core.Wad;
 
+/// <summary>
+/// Describes a sub-chunk in a chunked WAD payload
+/// </summary>
 public readonly struct WadSubchunk
 {
+    /// <summary>
+    /// Gets the stored size of the sub-chunk
+    /// </summary>
     public int CompressedSize { get; }
+
+    /// <summary>
+    /// Gets the decompressed size of the sub-chunk
+    /// </summary>
     public int UncompressedSize { get; }
+
+    /// <summary>
+    /// Gets the checksum of the sub-chunk
+    /// </summary>
     public ulong Checksum { get; }
+
+    /// <summary>
+    /// Creates a new <see cref="WadSubchunk"/> descriptor
+    /// </summary>
+    /// <param name="compressedSize">The stored size of the sub-chunk</param>
+    /// <param name="uncompressedSize">The decompressed size of the sub-chunk</param>
+    /// <param name="checksum">The checksum of the sub-chunk</param>
+    public WadSubchunk(int compressedSize, int uncompressedSize, ulong checksum = 0)
+    {
+        this.CompressedSize = compressedSize;
+        this.UncompressedSize = uncompressedSize;
+        this.Checksum = checksum;
+    }
 }


### PR DESCRIPTION
## Summary

This pull request introduces the `WadChunkDecompressor` class, separating chunk decompression logic from `WadFile`.

WAD chunk payloads can now be decoded independently, without requiring a complete `WadFile` instance. This is useful when working with external streams, WAD builders, or custom payload-processing workflows.

The PR also adds comprehensive unit test coverage for every supported decompression mode and refactors `WadFile` to delegate its decompression operations to the new component.

## Key Changes

### `WadChunkDecompressor.cs`

* Added a new standalone class responsible for decompressing WAD chunks.
* Supports all currently available compression schemes:
  * `None`
  * `GZip`
  * `Zstd`
  * `ZstdChunked`
* Added metadata validation to verify compressed and uncompressed payload sizes before allocating or accessing buffers.
* Prevents potential out-of-bounds reads, invalid allocations, and buffer overflows caused by malformed metadata.
* Added support for raw or uncompressed sub-chunk fallback within `ZstdChunked` payloads.
* Implements `IDisposable` to correctly manage the underlying `ZstdSharp.Decompressor` resource.

### `WadFile.cs`

* Refactored chunk and sub-chunk decompression to delegate to `WadChunkDecompressor`.
* Replaced the internal `ZstdSharp.Decompressor` field with a `WadChunkDecompressor` instance.
* Removed `DecompressZstdChunkedChunk`, as this responsibility now belongs to the standalone decompressor.
* Added bounds checks to `GetSubchunks` to safely validate references against the available sub-chunk table range.

### `WadSubchunk.cs`

* Added XML documentation for the struct and its properties:
  * `CompressedSize`
  * `UncompressedSize`
  * `Checksum`
* Added a public constructor to simplify the external creation of `WadSubchunk` descriptors.
* This is particularly useful for unit tests, custom WAD generation, and external payload-processing implementations.

## Tests

Expanded the test suite through `WadChunkDecompressorTests.cs` and `WadTests.cs`.

The new tests cover:

* Decompression using every supported compression scheme.
* Uncompressed payload handling.
* Standard Zstandard payloads.
* GZip payloads.
* Chunked Zstandard payloads.
* Raw sub-chunk fallback within `ZstdChunked` payloads.
* Compressed and uncompressed metadata size mismatches.
* Invalid or unsupported compression formats.
* Invalid sub-chunk table references.
* Operations attempted after the decompressor has been disposed.

## Benefits

* Decouples decompression from WAD file parsing.
* Makes the decompression logic reusable in external workflows.
* Improves validation and handling of malformed payloads.
* Reduces the responsibilities of `WadFile`.
* Provides broader test coverage for both expected and invalid inputs.
