### PR TITLE
fix: stabilize compressed hot-frame evaluation

### DIFF
--- a/src/LeagueToolkit.Tests/Core/Animation/CompressedAnimationAssetTests.cs
+++ b/src/LeagueToolkit.Tests/Core/Animation/CompressedAnimationAssetTests.cs
@@ -1,0 +1,126 @@
+using LeagueToolkit.Core.Animation;
+using System.Numerics;
+using System.Text;
+
+namespace LeagueToolkit.Tests.Core.Animation;
+
+public class CompressedAnimationAssetTests
+{
+    [Theory]
+    [InlineData(false, false)]
+    [InlineData(false, true)]
+    [InlineData(true, false)]
+    [InlineData(true, true)]
+    public void Should_Evaluate_Missing_And_Constant_Frame_Channels(
+        bool use32BitFrameKeys,
+        bool useKeyframeParametrization
+    )
+    {
+        using MemoryStream stream = CreateAnimation(use32BitFrameKeys, useKeyframeParametrization);
+        using IAnimationAsset animation = AnimationAsset.Load(stream);
+        Dictionary<uint, (Quaternion Rotation, Vector3 Translation, Vector3 Scale)> pose = [];
+
+        animation.Evaluate(animation.Duration * 0.5f, pose);
+
+        Assert.True(
+            MathF.Abs(Quaternion.Dot(Quaternion.Identity, pose[1].Rotation)) > 0.99999f,
+            $"Expected identity rotation, got {pose[1].Rotation}"
+        );
+        Assert.Equal(Vector3.Zero, pose[2].Translation);
+        Assert.Equal(Vector3.One, pose[3].Scale);
+        Assert.All(
+            pose.Values,
+            transform =>
+            {
+                Assert.True(IsFinite(transform.Rotation));
+                Assert.True(IsFinite(transform.Translation));
+                Assert.True(IsFinite(transform.Scale));
+            }
+        );
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void Should_Initialize_Hot_Frames_On_First_Evaluation(bool use32BitFrameKeys)
+    {
+        using MemoryStream stream = CreateAnimation(use32BitFrameKeys, false);
+        using IAnimationAsset animation = AnimationAsset.Load(stream);
+        Dictionary<uint, (Quaternion Rotation, Vector3 Translation, Vector3 Scale)> pose = [];
+
+        animation.Evaluate(0.001f, pose);
+
+        Assert.Equal(Vector3.Zero, pose[1].Scale);
+    }
+
+    private static MemoryStream CreateAnimation(bool use32BitFrameKeys, bool useKeyframeParametrization)
+    {
+        const int headerSize = 128;
+        const int jointCount = 3;
+        const int jumpCacheCount = 1;
+
+        int frameCount = use32BitFrameKeys ? 65_537 : 1;
+        int frameDataSize = frameCount * 10;
+        int jumpFrameSize = use32BitFrameKeys ? 48 : 24;
+        int jumpCacheDataSize = jumpFrameSize * jointCount * jumpCacheCount;
+        int framesOffset = headerSize;
+        int jumpCachesOffset = framesOffset + frameDataSize;
+        int jointHashesOffset = jumpCachesOffset + jumpCacheDataSize;
+
+        MemoryStream stream = new(jointHashesOffset + jointCount * sizeof(uint));
+        using (BinaryWriter writer = new(stream, Encoding.UTF8, true))
+        {
+            writer.Write("r3d2canm"u8);
+            writer.Write(3u);
+            writer.Write((uint)(stream.Capacity - 12));
+            writer.Write(0u);
+            writer.Write(useKeyframeParametrization ? 4u : 0u);
+            writer.Write(jointCount);
+            writer.Write(frameCount);
+            writer.Write(jumpCacheCount);
+            writer.Write(1f);
+            writer.Write(30f);
+
+            for (int i = 0; i < 6; i++)
+                writer.Write(0f);
+            for (int i = 0; i < 12; i++)
+                writer.Write(0f);
+
+            writer.Write(framesOffset - 12);
+            writer.Write(jumpCachesOffset - 12);
+            writer.Write(jointHashesOffset - 12);
+
+            for (int i = 0; i < frameCount; i++)
+            {
+                writer.Write((ushort)0);
+                writer.Write((ushort)0xC000);
+                writer.Write(0u);
+                writer.Write((ushort)0);
+            }
+
+            for (int jointId = 0; jointId < jointCount; jointId++)
+                for (int channel = 0; channel < 3; channel++)
+                    for (int key = 0; key < 4; key++)
+                    {
+                        bool isMissing = jointId == channel;
+                        if (use32BitFrameKeys)
+                            writer.Write(isMissing ? -1 : 0);
+                        else
+                            writer.Write(isMissing ? ushort.MaxValue : (ushort)0);
+                    }
+
+            writer.Write(1u);
+            writer.Write(2u);
+            writer.Write(3u);
+        }
+
+        stream.Position = 0;
+        return stream;
+    }
+
+    private static bool IsFinite(Quaternion value) =>
+        float.IsFinite(value.X) && float.IsFinite(value.Y) && float.IsFinite(value.Z) && float.IsFinite(value.W);
+
+    private static bool IsFinite(Vector3 value) =>
+        float.IsFinite(value.X) && float.IsFinite(value.Y) && float.IsFinite(value.Z);
+}

--- a/src/LeagueToolkit/Core/Animation/HotFrame.cs
+++ b/src/LeagueToolkit/Core/Animation/HotFrame.cs
@@ -13,6 +13,7 @@ internal struct HotFrameEvaluator
 
     public HotFrameEvaluator(int jointCount)
     {
+        this.LastEvaluationTime = -1.0f;
         this.HotFrames = new JointHotFrame[jointCount];
     }
 
@@ -22,6 +23,15 @@ internal struct HotFrameEvaluator
         ReadOnlySpan<CompressedFrame> frames
     )
     {
+        if (AreFrameKeysMissing(frameKeys, frames.Length))
+        {
+            this.HotFrames[jointId] = this.HotFrames[jointId] with
+            {
+                HasRotationFrames = false
+            };
+            return;
+        }
+
         Span<QuaternionHotFrame> hotFrames = stackalloc QuaternionHotFrame[4];
         for (int i = 0; i < 4; i++)
         {
@@ -42,6 +52,7 @@ internal struct HotFrameEvaluator
 
         this.HotFrames[jointId] = this.HotFrames[jointId] with
         {
+            HasRotationFrames = true,
             RotationP0 = hotFrames[0],
             RotationP1 = hotFrames[1],
             RotationP2 = hotFrames[2],
@@ -57,6 +68,15 @@ internal struct HotFrameEvaluator
         Vector3 max
     )
     {
+        if (AreFrameKeysMissing(frameKeys, frames.Length))
+        {
+            this.HotFrames[jointId] = this.HotFrames[jointId] with
+            {
+                HasTranslationFrames = false
+            };
+            return;
+        }
+
         Span<VectorHotFrame> hotFrames = stackalloc VectorHotFrame[4];
         for (int i = 0; i < 4; i++)
         {
@@ -70,6 +90,7 @@ internal struct HotFrameEvaluator
 
         this.HotFrames[jointId] = this.HotFrames[jointId] with
         {
+            HasTranslationFrames = true,
             TranslationP0 = hotFrames[0],
             TranslationP1 = hotFrames[1],
             TranslationP2 = hotFrames[2],
@@ -85,6 +106,15 @@ internal struct HotFrameEvaluator
         Vector3 max
     )
     {
+        if (AreFrameKeysMissing(frameKeys, frames.Length))
+        {
+            this.HotFrames[jointId] = this.HotFrames[jointId] with
+            {
+                HasScaleFrames = false
+            };
+            return;
+        }
+
         Span<VectorHotFrame> hotFrames = stackalloc VectorHotFrame[4];
         for (int i = 0; i < 4; i++)
         {
@@ -98,16 +128,35 @@ internal struct HotFrameEvaluator
 
         this.HotFrames[jointId] = this.HotFrames[jointId] with
         {
+            HasScaleFrames = true,
             ScaleP0 = hotFrames[0],
             ScaleP1 = hotFrames[1],
             ScaleP2 = hotFrames[2],
             ScaleP3 = hotFrames[3]
         };
     }
+
+    private static bool AreFrameKeysMissing(ReadOnlySpan<int> frameKeys, int frameCount)
+    {
+        // Compressed animations use all-bits-set keys for transform channels that have no frames.
+        int missingKey = frameKeys[0];
+        if (missingKey is not -1 && (missingKey != ushort.MaxValue || missingKey < frameCount))
+            return false;
+
+        for (int i = 1; i < frameKeys.Length; i++)
+            if (frameKeys[i] != missingKey)
+                return false;
+
+        return true;
+    }
 }
 
 internal struct JointHotFrame
 {
+    public bool HasRotationFrames { get; init; }
+    public bool HasTranslationFrames { get; init; }
+    public bool HasScaleFrames { get; init; }
+
     public QuaternionHotFrame RotationP0;
     public QuaternionHotFrame RotationP1;
     public QuaternionHotFrame RotationP2;
@@ -126,6 +175,11 @@ internal struct JointHotFrame
     #region Parametrized Catmull Rom
     public Quaternion SampleRotationParametrized(ushort time)
     {
+        if (!this.HasRotationFrames)
+            return Quaternion.Identity;
+        if (this.RotationP1.Time == this.RotationP2.Time)
+            return this.RotationP1.Value;
+
         var (amount, scaleIn, scaleOut) = CurveSampler.CreateCatmullRomKeyframeWeights(
             time,
             this.RotationP0.Time,
@@ -147,6 +201,11 @@ internal struct JointHotFrame
 
     public Vector3 SampleTranslationParametrized(ushort time)
     {
+        if (!this.HasTranslationFrames)
+            return Vector3.Zero;
+        if (this.TranslationP1.Time == this.TranslationP2.Time)
+            return this.TranslationP1.Value;
+
         var (amount, scaleIn, scaleOut) = CurveSampler.CreateCatmullRomKeyframeWeights(
             time,
             this.TranslationP0.Time,
@@ -168,6 +227,11 @@ internal struct JointHotFrame
 
     public Vector3 SampleScaleParametrized(ushort time)
     {
+        if (!this.HasScaleFrames)
+            return Vector3.One;
+        if (this.ScaleP1.Time == this.ScaleP2.Time)
+            return this.ScaleP1.Value;
+
         var (amount, scaleIn, scaleOut) = CurveSampler.CreateCatmullRomKeyframeWeights(
             time,
             this.ScaleP0.Time,
@@ -191,6 +255,11 @@ internal struct JointHotFrame
     #region Uniform Catmull Rom
     public Quaternion SampleRotationUniform(ushort time)
     {
+        if (!this.HasRotationFrames)
+            return Quaternion.Identity;
+        if (this.RotationP1.Time == this.RotationP2.Time)
+            return this.RotationP1.Value;
+
         float t_d = this.RotationP2.Time - this.RotationP1.Time;
         float amount = (time - this.RotationP1.Time) / t_d;
 
@@ -207,6 +276,11 @@ internal struct JointHotFrame
 
     public Vector3 SampleTranslationUniform(ushort time)
     {
+        if (!this.HasTranslationFrames)
+            return Vector3.Zero;
+        if (this.TranslationP1.Time == this.TranslationP2.Time)
+            return this.TranslationP1.Value;
+
         float t_d = this.TranslationP2.Time - this.TranslationP1.Time;
         float amount = (time - this.TranslationP1.Time) / t_d;
 
@@ -223,6 +297,11 @@ internal struct JointHotFrame
 
     public Vector3 SampleScaleUniform(ushort time)
     {
+        if (!this.HasScaleFrames)
+            return Vector3.One;
+        if (this.ScaleP1.Time == this.ScaleP2.Time)
+            return this.ScaleP1.Value;
+
         float t_d = this.ScaleP2.Time - this.ScaleP1.Time;
         float amount = (time - this.ScaleP1.Time) / t_d;
 


### PR DESCRIPTION
## What and why

  Fixes compressed ANM evaluation for animations containing missing or constant transform channels.

  Some animations use `ushort.MaxValue` or `-1` frame keys to indicate that a joint channel has no frames. These
  sentinel values were previously interpreted as frame indices, causing `IndexOutOfRangeException`.

  The hot-frame evaluator could also skip initialization during the first playback cycle because its initial evaluation
  time was `0`. This produced collapsed or invisible models until the animation completed its first loop.

  This change:

  - Detects missing 16-bit and 32-bit frame keys.
  - Uses neutral transforms for missing channels.
  - Safely handles constant curves with identical key times.
  - Initializes hot frames during the first evaluation.
  - Preserves existing interpolation behavior for regular animations.

  ## How it was tested

  Command:

  `dotnet test src/LeagueToolkit.Tests/LeagueToolkit.Tests.csproj --no-restore`

  Result: 148 tests passed.

  Regression coverage includes:

  - Missing rotation, translation, and scale channels.
  - Constant transform channels.
  - 16-bit and 32-bit frame keys.
  - Uniform and parametrized interpolation.
  - First evaluation near animation time zero.
  - Manual playback validation with compressed companion animations that previously crashed or produced an invalid first
  loop.

  ## Checklist

  - [x] Title follows Conventional Commits.
  - [x] Full test suite passes.
  - [x] Tests added for the fixed bugs.
  - [x] README / docs not required because this is an internal animation evaluation fix.